### PR TITLE
Add configuration option to disable spoolman integration

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -59,6 +59,7 @@ void Config::init(std::string config_path) {
   };
 
   json cooldown_conf = {{ "cooldown", "SET_HEATER_TEMPERATURE HEATER=extruder TARGET=0\nSET_HEATER_TEMPERATURE HEATER=heater_bed TARGET=0"}};
+
   json default_macros_conf = {
     {"load_filament", "LOAD_MATERIAL"},
     {"unload_filament", "QUIT_MATERIAL"}
@@ -82,6 +83,7 @@ void Config::init(std::string config_path) {
 	      {"monitored_sensors", sensors_conf},
 	      {"fans", fans_conf},
 	      {"default_macros", default_macros_conf},
+	      {"disable_spoolman", false}
 	    }
 	  }}
       }
@@ -110,6 +112,11 @@ void Config::init(std::string config_path) {
     if (!default_macros.contains("cooldown")) {
       default_macros.merge_patch(cooldown_conf);
     }
+  }
+
+  auto &disable_spoolman = data[json::json_pointer(df() + "disable_spoolman")];
+  if (disable_spoolman.is_null()) {
+    data[json::json_pointer(df() + "disable_spoolman")] = false;
   }
 
   auto &guppy_init = data["/guppy_init_script"_json_pointer];


### PR DESCRIPTION
New printer configuration option "disable_spoolman" has been added to allow the spoolman integration to be disabled on a per-printer basis. Setting this option to true only disables the guppyscreen integration with spoolman and does not affect Moonraker.