### PR TITLE
Option to swap Z axis icons, adapt print status flow display for small screens

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,10 @@ ifdef EVDEV_CALIBRATE
 DEFINES +=  -D EVDEV_CALIBRATE
 endif
 
+ifdef Z_PLUS_UPARROW
+DEFINES += -D Z_PLUS_UPARROW
+endif
+
 # SIMULATION is enabled by default, need CROSS_COMPILE variable to do MIPS build
 ifndef CROSS_COMPILE
 DEFINES +=  -D LV_BUILD_TEST=0 -D SIMULATOR

--- a/lv_touch_calibration/lv_tc.c
+++ b/lv_touch_calibration/lv_tc.c
@@ -6,6 +6,8 @@
 
 #include "math.h"
 
+#include <stdio.h>
+
 #ifdef ESP_PLATFORM
     #include "esp_log.h"
 #endif
@@ -140,14 +142,22 @@ void lv_tc_compute_coeff(lv_point_t *scrP, lv_point_t *tchP, bool save) {   //Th
     #endif
 }
 
+static lv_point_t last_pressed_point = {0,0};
+static lv_indev_state_t last_state = 0;
 lv_point_t _lv_tc_transform_point_indev(lv_indev_data_t *data) {
     if(data->state == LV_INDEV_STATE_PRESSED) {
+        // Pressed - just return coordinates
+        last_pressed_point = data->point;
+        last_state = data->state;
         return lv_tc_transform_point(data->point);
-    } else {
-        //Reject invalid points if the touch panel is in released state
-        lv_point_t point = {0, 0};
-        return point;
+    } else if(data->state == LV_INDEV_STATE_RELEASED && last_state == LV_INDEV_STATE_PRESSED) {
+        // Released - ensure reporting of coordinates where the touch was last seen
+        last_state = data->state;
+        return lv_tc_transform_point(last_pressed_point);
     }
+    // Invalid state
+    lv_point_t point = {0, 0};
+    return point;
 }
 
 lv_point_t lv_tc_transform_point(lv_point_t point) {

--- a/src/button_container.cpp
+++ b/src/button_container.cpp
@@ -3,7 +3,7 @@
 #include "spdlog/spdlog.h"
 
 ButtonContainer::ButtonContainer(lv_obj_t *parent,
-				 const void *btn_img,
+				 const void *btn_img, //If chabgeable, should be non-const
 				 const char *text,
 				 lv_event_cb_t cb,
 				 void* user_data,
@@ -91,6 +91,10 @@ void ButtonContainer::enable() {
 
 void ButtonContainer::hide() {
   lv_obj_add_flag(btn_cont, LV_OBJ_FLAG_HIDDEN);
+}
+
+void ButtonContainer::set_image(const void *img) {
+  lv_imgbtn_set_src(btn, LV_IMGBTN_STATE_RELEASED, NULL, img, NULL);
 }
 
 void ButtonContainer::handle_callback(lv_event_t *e) {

--- a/src/button_container.cpp
+++ b/src/button_container.cpp
@@ -3,7 +3,7 @@
 #include "spdlog/spdlog.h"
 
 ButtonContainer::ButtonContainer(lv_obj_t *parent,
-				 const void *btn_img, //If chabgeable, should be non-const
+				 const void *btn_img,
 				 const char *text,
 				 lv_event_cb_t cb,
 				 void* user_data,

--- a/src/button_container.h
+++ b/src/button_container.h
@@ -23,6 +23,8 @@ class ButtonContainer {
   void enable();
   void hide();
 
+  void set_image(const void *img);
+
   void handle_callback(lv_event_t *event);
 
   void handle_prompt();

--- a/src/finetune_panel.cpp
+++ b/src/finetune_panel.cpp
@@ -22,13 +22,8 @@ FineTunePanel::FineTunePanel(KWebSocketClient &websocket_client, std::mutex &l)
   , panel_cont(lv_obj_create(lv_scr_act()))
   , values_cont(lv_obj_create(panel_cont))
   , zreset_btn(panel_cont, &refresh_img, "Reset Z", &FineTunePanel::_handle_zoffset, this)
-#ifdef Z_PLUS_UPARROW
-  , zup_btn(panel_cont, &z_farther, "Z+", &FineTunePanel::_handle_zoffset, this)
-  , zdown_btn(panel_cont, &z_closer, "Z-", &FineTunePanel::_handle_zoffset, this)
-#else
   , zup_btn(panel_cont, &z_closer, "Z+", &FineTunePanel::_handle_zoffset, this)
   , zdown_btn(panel_cont, &z_farther, "Z-", &FineTunePanel::_handle_zoffset, this)
-#endif
   , pareset_btn(panel_cont, &refresh_img, "Reset PA", &FineTunePanel::_handle_pa, this)
   , paup_btn(panel_cont, &pa_plus_img, "PA+", &FineTunePanel::_handle_pa, this)
   , padown_btn(panel_cont, &pa_minus_img, "PA-", &FineTunePanel::_handle_pa, this)
@@ -93,6 +88,8 @@ FineTunePanel::FineTunePanel(KWebSocketClient &websocket_client, std::mutex &l)
   lv_obj_set_grid_cell(back_btn.get_container(), LV_GRID_ALIGN_CENTER, 4, 1, LV_GRID_ALIGN_CENTER, 3, 1);
 
   ws.register_notify_update(this);
+
+  conf = Config::get_instance();
 }
 
 FineTunePanel::~FineTunePanel() {
@@ -128,6 +125,22 @@ void FineTunePanel::foreground() {
   if (!v.is_null()) {
     flow_factor.update_label(fmt::format("{}%",
 	   static_cast<int>(v.template get<double>() * 100)).c_str());
+  }
+
+  //Set the Z axis buttons
+  v = conf->get_json("/z_plus_uparrow");
+  bool uparrow = false;
+  if (!v.is_null()) {
+    uparrow = v.template get<bool>();
+  } 
+  if (uparrow) {
+    // UP arrow
+    zup_btn.set_image(&z_farther);
+    zdown_btn.set_image(&z_closer);
+  } else {
+    // DOWN arrow
+    zup_btn.set_image(&z_closer);
+    zdown_btn.set_image(&z_farther);
   }
   
   lv_obj_move_foreground(panel_cont);

--- a/src/finetune_panel.cpp
+++ b/src/finetune_panel.cpp
@@ -22,8 +22,13 @@ FineTunePanel::FineTunePanel(KWebSocketClient &websocket_client, std::mutex &l)
   , panel_cont(lv_obj_create(lv_scr_act()))
   , values_cont(lv_obj_create(panel_cont))
   , zreset_btn(panel_cont, &refresh_img, "Reset Z", &FineTunePanel::_handle_zoffset, this)
+#ifdef Z_PLUS_UPARROW
+  , zup_btn(panel_cont, &z_farther, "Z+", &FineTunePanel::_handle_zoffset, this)
+  , zdown_btn(panel_cont, &z_closer, "Z-", &FineTunePanel::_handle_zoffset, this)
+#else
   , zup_btn(panel_cont, &z_closer, "Z+", &FineTunePanel::_handle_zoffset, this)
   , zdown_btn(panel_cont, &z_farther, "Z-", &FineTunePanel::_handle_zoffset, this)
+#endif
   , pareset_btn(panel_cont, &refresh_img, "Reset PA", &FineTunePanel::_handle_pa, this)
   , paup_btn(panel_cont, &pa_plus_img, "PA+", &FineTunePanel::_handle_pa, this)
   , padown_btn(panel_cont, &pa_minus_img, "PA-", &FineTunePanel::_handle_pa, this)

--- a/src/finetune_panel.h
+++ b/src/finetune_panel.h
@@ -7,7 +7,6 @@
 #include "image_label.h"
 #include "websocket_client.h"
 #include "notify_consumer.h"
-#include "sysinfo_panel.h"
 #include "config.h"
 
 #include <mutex>

--- a/src/finetune_panel.h
+++ b/src/finetune_panel.h
@@ -7,6 +7,8 @@
 #include "image_label.h"
 #include "websocket_client.h"
 #include "notify_consumer.h"
+#include "sysinfo_panel.h"
+#include "config.h"
 
 #include <mutex>
 
@@ -71,6 +73,7 @@ class FineTunePanel : public NotifyConsumer {
   ImageLabel pa;
   ImageLabel speed_factor;
   ImageLabel flow_factor;
+  Config *conf;
 };
 
 #endif  // __FINETINE_PANEL_H__

--- a/src/homing_panel.cpp
+++ b/src/homing_panel.cpp
@@ -25,8 +25,13 @@ HomingPanel::HomingPanel(KWebSocketClient &websocket_client, std::mutex &lock)
   , y_down_btn(homing_cont, &arrow_down, "Y-", &HomingPanel::_handle_callback, this)    
   , x_up_btn(homing_cont, &arrow_right, "X+", &HomingPanel::_handle_callback, this)
   , x_down_btn(homing_cont, &arrow_left, "X-", &HomingPanel::_handle_callback, this)
+#ifdef Z_PLUS_UPARROW
+  , z_up_btn(homing_cont, &z_farther, "Z+", &HomingPanel::_handle_callback, this)
+  , z_down_btn(homing_cont, &z_closer, "Z-", &HomingPanel::_handle_callback, this)
+#else
   , z_up_btn(homing_cont, &z_closer, "Z+", &HomingPanel::_handle_callback, this)
   , z_down_btn(homing_cont, &z_farther, "Z-", &HomingPanel::_handle_callback, this)
+#endif
   , emergency_btn(homing_cont, &emergency, "Stop", &HomingPanel::_handle_callback, this,
 		  "Do you want to emergency stop?",
 		  [&websocket_client]() {

--- a/src/homing_panel.cpp
+++ b/src/homing_panel.cpp
@@ -25,13 +25,8 @@ HomingPanel::HomingPanel(KWebSocketClient &websocket_client, std::mutex &lock)
   , y_down_btn(homing_cont, &arrow_down, "Y-", &HomingPanel::_handle_callback, this)    
   , x_up_btn(homing_cont, &arrow_right, "X+", &HomingPanel::_handle_callback, this)
   , x_down_btn(homing_cont, &arrow_left, "X-", &HomingPanel::_handle_callback, this)
-#ifdef Z_PLUS_UPARROW
-  , z_up_btn(homing_cont, &z_farther, "Z+", &HomingPanel::_handle_callback, this)
-  , z_down_btn(homing_cont, &z_closer, "Z-", &HomingPanel::_handle_callback, this)
-#else
   , z_up_btn(homing_cont, &z_closer, "Z+", &HomingPanel::_handle_callback, this)
   , z_down_btn(homing_cont, &z_farther, "Z-", &HomingPanel::_handle_callback, this)
-#endif
   , emergency_btn(homing_cont, &emergency, "Stop", &HomingPanel::_handle_callback, this,
 		  "Do you want to emergency stop?",
 		  [&websocket_client]() {
@@ -134,6 +129,10 @@ void HomingPanel::foreground() {
       y_down_btn.disable();
     }
 
+    //Set the Z axis buttons
+    z_up_btn.set_image(&z_farther);
+    z_down_btn.set_image(&z_closer);
+
     if (homed_axes.find("z") != std::string::npos) {
       z_up_btn.enable();
       z_down_btn.enable();
@@ -141,6 +140,23 @@ void HomingPanel::foreground() {
       z_up_btn.disable();
       z_down_btn.disable();
     }
+  }
+
+  //Set the Z axis buttons
+  conf = Config::get_instance();
+  v = conf->get_json("/z_plus_uparrow");
+  bool uparrow = false;
+  if (!v.is_null()) {
+    uparrow = v.template get<bool>();
+  } 
+  if (uparrow) {
+    // UP arrow
+    z_up_btn.set_image(&z_farther);
+    z_down_btn.set_image(&z_closer);
+  } else {
+    // DOWN arrow
+    z_up_btn.set_image(&z_closer);
+    z_down_btn.set_image(&z_farther);
   }
 
   lv_obj_move_foreground(homing_cont);

--- a/src/homing_panel.h
+++ b/src/homing_panel.h
@@ -47,7 +47,6 @@ class HomingPanel : public NotifyConsumer {
   ButtonContainer back_btn;
   Selector distance_selector;
   Config *conf;
-
   
   // lv_obj_t *selector_label;
   // lv_obj_t *btnm;

--- a/src/homing_panel.h
+++ b/src/homing_panel.h
@@ -6,6 +6,7 @@
 #include "websocket_client.h"
 #include "selector.h"
 #include "notify_consumer.h"
+#include "config.h"
 
 #include <mutex>
 
@@ -45,6 +46,8 @@ class HomingPanel : public NotifyConsumer {
   ButtonContainer motoroff_btn;
   ButtonContainer back_btn;
   Selector distance_selector;
+  Config *conf;
+
   
   // lv_obj_t *selector_label;
   // lv_obj_t *btnm;

--- a/src/print_status_panel.cpp
+++ b/src/print_status_panel.cpp
@@ -518,7 +518,11 @@ void PrintStatusPanel::update_flow_rate(double filament_used) {
       flow = filament_xsection * filament_delta / delta;
       
       spdlog::trace("caculated flow {}", flow); 
-      flow_rate.update_label(fmt::format("{:.2f} mm3/s", flow).c_str());
+      #ifdef GUPPY_SMALL_SCREEN
+        flow_rate.update_label(fmt::format("{:.1f} mm3/s", flow).c_str());
+      #else
+        flow_rate.update_label(fmt::format("{:.2f} mm3/s", flow).c_str());
+      #endif
     }
 
     last_filament_used = filament_used;

--- a/src/sysinfo_panel.cpp
+++ b/src/sysinfo_panel.cpp
@@ -37,11 +37,6 @@ static std::map<std::string, uint32_t> sleep_label_to_sec = {
   {"5 Hours", 18000} // 5 hour
 };
 
-std::vector<std::string> SysInfoPanel::z_plus_types = {
-  "UP arrow",
-  "DOWN arrow"
-};
-
 SysInfoPanel::SysInfoPanel()
   : cont(lv_obj_create(lv_scr_act()))
   , left_cont(lv_obj_create(cont))
@@ -203,8 +198,7 @@ void SysInfoPanel::foreground() {
 
 void SysInfoPanel::handle_callback(lv_event_t *e)
 {
-  if (lv_event_get_code(e) == LV_EVENT_CLICKED)
-  {
+  if (lv_event_get_code(e) == LV_EVENT_CLICKED) {
     lv_obj_t *btn = lv_event_get_current_target(e);
 
     if (btn == back_btn.get_container())
@@ -212,17 +206,13 @@ void SysInfoPanel::handle_callback(lv_event_t *e)
       lv_obj_move_background(cont);
     }
   }
-  else if (lv_event_get_code(e) == LV_EVENT_VALUE_CHANGED)
-  {
+  else if (lv_event_get_code(e) == LV_EVENT_VALUE_CHANGED) {
     lv_obj_t *obj = lv_event_get_target(e);
     Config *conf = Config::get_instance();
-    if (obj == loglevel_dd)
-    {
+    if (obj == loglevel_dd) {
       auto idx = lv_dropdown_get_selected(loglevel_dd);
-      if (idx != loglevel)
-      {
-        if (loglevel < log_levels.size())
-        {
+      if (idx != loglevel) {
+        if (loglevel < log_levels.size()) {
           loglevel = idx;
           auto ll = spdlog::level::from_str(log_levels[loglevel]);
 
@@ -234,14 +224,12 @@ void SysInfoPanel::handle_callback(lv_event_t *e)
         }
       }
     }
-    else if (obj == prompt_estop_toggle)
-    {
+    else if (obj == prompt_estop_toggle) {
       bool should_prompt = lv_obj_has_state(prompt_estop_toggle, LV_STATE_CHECKED);
       conf->set<bool>("/prompt_emergency_stop", should_prompt);
       conf->save();
     }
-    else if (obj == display_sleep_dd)
-    {
+    else if (obj == display_sleep_dd) {
       char buf[64];
       lv_dropdown_get_selected_str(display_sleep_dd, buf, sizeof(buf));
       std::string sleep_label = std::string(buf);
@@ -252,8 +240,7 @@ void SysInfoPanel::handle_callback(lv_event_t *e)
         conf->save();
       }
     }
-    else if (obj == z_icon_toggle)
-    {
+    else if (obj == z_icon_toggle) {
       bool use_up = lv_obj_has_state(z_icon_toggle, LV_STATE_CHECKED);
       conf->set<bool>("/z_plus_uparrow", use_up);
       conf->save();

--- a/src/sysinfo_panel.cpp
+++ b/src/sysinfo_panel.cpp
@@ -37,6 +37,11 @@ static std::map<std::string, uint32_t> sleep_label_to_sec = {
   {"5 Hours", 18000} // 5 hour
 };
 
+std::vector<std::string> SysInfoPanel::z_plus_types = {
+  "UP arrow",
+  "DOWN arrow"
+};
+
 SysInfoPanel::SysInfoPanel()
   : cont(lv_obj_create(lv_scr_act()))
   , left_cont(lv_obj_create(cont))
@@ -56,6 +61,11 @@ SysInfoPanel::SysInfoPanel()
   , estop_toggle_cont(lv_obj_create(left_cont))
   , prompt_estop_toggle(lv_switch_create(estop_toggle_cont))
   , back_btn(cont, &back, "Back", &SysInfoPanel::_handle_callback, this)
+
+    // Z axis icons
+  , z_icon_toggle_cont(lv_obj_create(left_cont))
+  , z_icon_toggle(lv_switch_create(z_icon_toggle_cont))
+
 {
   lv_obj_move_background(cont);
   lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLLABLE);
@@ -142,6 +152,30 @@ SysInfoPanel::SysInfoPanel()
   lv_obj_add_event_cb(prompt_estop_toggle, &SysInfoPanel::_handle_callback,
 		      LV_EVENT_VALUE_CHANGED, this);
 
+    /* Z icon selection */
+  lv_obj_set_size(z_icon_toggle_cont, LV_PCT(100), LV_SIZE_CONTENT);
+  lv_obj_set_style_pad_all(z_icon_toggle_cont, 0, 0);
+
+  l = lv_label_create(z_icon_toggle_cont);
+  lv_label_set_text(l, "Z+ UP-arrow");
+  lv_obj_align(l, LV_ALIGN_LEFT_MID, 0, 0);
+  lv_obj_align(z_icon_toggle, LV_ALIGN_RIGHT_MID, 0, 0);
+
+  v = conf->get_json("/z_plus_uparrow");
+  if (!v.is_null()) {
+    if (v.template get<bool>()) {
+      lv_obj_add_state(z_icon_toggle, LV_STATE_CHECKED);
+    } else {
+      lv_obj_clear_state(z_icon_toggle, LV_STATE_CHECKED);
+    }
+  } else {
+    // Default is cleared
+    lv_obj_clear_state(z_icon_toggle, LV_STATE_CHECKED);
+  }
+
+  lv_obj_add_event_cb(z_icon_toggle, &SysInfoPanel::_handle_callback,
+		      LV_EVENT_VALUE_CHANGED, this);
+
   lv_obj_add_flag(back_btn.get_container(), LV_OBJ_FLAG_FLOATING);	
   lv_obj_align(back_btn.get_container(), LV_ALIGN_BOTTOM_RIGHT, 0, 0);
 }
@@ -167,45 +201,62 @@ void SysInfoPanel::foreground() {
 					       fmt::join(network_detail, "\n")).c_str());
 }
 
-void SysInfoPanel::handle_callback(lv_event_t *e) {
-  if (lv_event_get_code(e) == LV_EVENT_CLICKED) {
+void SysInfoPanel::handle_callback(lv_event_t *e)
+{
+  if (lv_event_get_code(e) == LV_EVENT_CLICKED)
+  {
     lv_obj_t *btn = lv_event_get_current_target(e);
 
-    if (btn == back_btn.get_container()) {
+    if (btn == back_btn.get_container())
+    {
       lv_obj_move_background(cont);
     }
-  } else if (lv_event_get_code(e) == LV_EVENT_VALUE_CHANGED) {
+  }
+  else if (lv_event_get_code(e) == LV_EVENT_VALUE_CHANGED)
+  {
     lv_obj_t *obj = lv_event_get_target(e);
-    Config *conf = Config::get_instance();    
-    if (obj == loglevel_dd) {
+    Config *conf = Config::get_instance();
+    if (obj == loglevel_dd)
+    {
       auto idx = lv_dropdown_get_selected(loglevel_dd);
-      if (idx != loglevel) {
-	if (loglevel < log_levels.size()) {
-	  loglevel = idx;	
-	  auto ll = spdlog::level::from_str(log_levels[loglevel]);
+      if (idx != loglevel)
+      {
+        if (loglevel < log_levels.size())
+        {
+          loglevel = idx;
+          auto ll = spdlog::level::from_str(log_levels[loglevel]);
 
-	  spdlog::set_level(ll);
-	  spdlog::flush_on(ll);
-	  spdlog::debug("setting log_level to {}", log_levels[loglevel]);
-	  conf->set<std::string>(conf->df() + "log_level", log_levels[loglevel]);
-	  conf->save();
-	}
+          spdlog::set_level(ll);
+          spdlog::flush_on(ll);
+          spdlog::debug("setting log_level to {}", log_levels[loglevel]);
+          conf->set<std::string>(conf->df() + "log_level", log_levels[loglevel]);
+          conf->save();
+        }
       }
-    } else if (obj == prompt_estop_toggle) {
+    }
+    else if (obj == prompt_estop_toggle)
+    {
       bool should_prompt = lv_obj_has_state(prompt_estop_toggle, LV_STATE_CHECKED);
       conf->set<bool>("/prompt_emergency_stop", should_prompt);
       conf->save();
-    } else if (obj == display_sleep_dd) {
+    }
+    else if (obj == display_sleep_dd)
+    {
       char buf[64];
       lv_dropdown_get_selected_str(display_sleep_dd, buf, sizeof(buf));
       std::string sleep_label = std::string(buf);
       const auto &el = sleep_label_to_sec.find(sleep_label);
-      if (el != sleep_label_to_sec.end()) {
-	conf->set<int32_t>("/display_sleep_sec", el->second);
-	conf->save();
+      if (el != sleep_label_to_sec.end())
+      {
+        conf->set<int32_t>("/display_sleep_sec", el->second);
+        conf->save();
       }
+    }
+    else if (obj == z_icon_toggle)
+    {
+      bool use_up = lv_obj_has_state(z_icon_toggle, LV_STATE_CHECKED);
+      conf->set<bool>("/z_plus_uparrow", use_up);
+      conf->save();
     }
   }
 }
-
-  

--- a/src/sysinfo_panel.h
+++ b/src/sysinfo_panel.h
@@ -7,11 +7,6 @@
 #include <vector>
 #include <string>
 
-const std::vector<std::string> z_plus_types = {
-  "UP arrow",
-  "DOWN arrow"
-};
-
 class SysInfoPanel {
  public:
   SysInfoPanel();
@@ -47,8 +42,6 @@ class SysInfoPanel {
   ButtonContainer back_btn;
 
   static std::vector<std::string> log_levels;
-
-  static std::vector<std::string> z_plus_types;
   
 };
 

--- a/src/sysinfo_panel.h
+++ b/src/sysinfo_panel.h
@@ -7,6 +7,11 @@
 #include <vector>
 #include <string>
 
+const std::vector<std::string> z_plus_types = {
+  "UP arrow",
+  "DOWN arrow"
+};
+
 class SysInfoPanel {
  public:
   SysInfoPanel();
@@ -35,10 +40,15 @@ class SysInfoPanel {
 
   lv_obj_t *estop_toggle_cont;
   lv_obj_t *prompt_estop_toggle;
+
+  lv_obj_t *z_icon_toggle_cont;
+  lv_obj_t *z_icon_toggle;
   
   ButtonContainer back_btn;
 
   static std::vector<std::string> log_levels;
+
+  static std::vector<std::string> z_plus_types;
   
 };
 


### PR DESCRIPTION
As suggested in response to #57, an option to swap the Z axis icons on the fine tune and homing screens. Compilation with Z_PLUS_UPARROW defined will associate "Z+" with the up-arrow icon, etc.  Of course, an entry in guppyscreen.json would be another (preferred?) approach.

Also, if GUPPY_SCREEN_SMALLSCREEN is defined, the flow display on the print status screen is made less crowded by dropping the precision to 1 decimal point.