### PR TITLE
Improve pulldown selection reliability

### DIFF
--- a/lv_touch_calibration/lv_tc.c
+++ b/lv_touch_calibration/lv_tc.c
@@ -140,14 +140,22 @@ void lv_tc_compute_coeff(lv_point_t *scrP, lv_point_t *tchP, bool save) {   //Th
     #endif
 }
 
+static lv_point_t last_pressed_point = {0,0};
+static lv_indev_state_t last_state = 0;
 lv_point_t _lv_tc_transform_point_indev(lv_indev_data_t *data) {
-    if(data->state == LV_INDEV_STATE_PRESSED || data->state == LV_INDEV_STATE_RELEASED) {
+    if(data->state == LV_INDEV_STATE_PRESSED) {
+        // Pressed - just return coordinates
+        last_pressed_point = data->point;
+        last_state = data->state;
         return lv_tc_transform_point(data->point);
-    } else {
-        //Reject invalid points if the touch panel is in released state
-        lv_point_t point = {0, 0};
-        return point;
+    } else if(data->state == LV_INDEV_STATE_RELEASED && last_state == LV_INDEV_STATE_PRESSED) {
+        // Released - ensure reporting of coordinates where the touch was last seen
+        last_state = data->state;
+        return lv_tc_transform_point(last_pressed_point);
     }
+    // Invalid state
+    lv_point_t point = {0, 0};
+    return point;
 }
 
 lv_point_t lv_tc_transform_point(lv_point_t point) {


### PR DESCRIPTION
Possibly due to sampling rate, release events, which trigger pulldown list selections, sometimes had incorrect coordinates. This code reports touch releases at the last-seen touch point.