### PR TITLE
SAVE_INPUT_SHAPER is not a valid command, SET_INPUT_SHAPER is.

### DIFF
--- a/src/inputshaper_panel.cpp
+++ b/src/inputshaper_panel.cpp
@@ -342,7 +342,7 @@ void InputShaperPanel::handle_callback(lv_event_t *event) {
     char ybuf[10];
     lv_dropdown_get_selected_str(yshaper_dd, ybuf, sizeof(ybuf));
     
-    ws.gcode_script(fmt::format("SAVE_INPUT_SHAPER SHAPER_FREQ_X={} SHAPER_TYPE_X={} SHAPER_FREQ_Y={} SHAPER_TYPE_Y={}\nSAVE_CONFIG",
+    ws.gcode_script(fmt::format("SET_INPUT_SHAPER SHAPER_FREQ_X={} SHAPER_TYPE_X={} SHAPER_FREQ_Y={} SHAPER_TYPE_Y={}\nSAVE_CONFIG",
 				xhz, xbuf, yhz, ybuf));
 
   } else if (btn == back_btn.get_container()) {


### PR DESCRIPTION
See https://www.klipper3d.org/G-Codes.html?h=set_input_shaper#set_input_shaper

Maybe this is k1 specific but SAVE_INPUT_SHAPER is not a klipper command in at least v0.11. I have not change the one in the k1 scripts file.