### PR TITLE
Prevent line breaks in env var list

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -16,9 +16,9 @@ Dependencies:
 The Guppy Screen uses features (filesystem) from C++17, so a gcc/g++ version (7.2+) with C++17 support is required.
 
 ### Environment Variables
-`CROSS_COMPILE` - The prefix to the toolchain architecture, e.g. `mips-linux-gnu-`
-`SIMULATION` - Define it to build with SDL for running on your local machine.
-`ZBOLT` - Define it to use the Z-Bolt icon set. By default the build uses the Material Design Icons.
+`CROSS_COMPILE` - The prefix to the toolchain architecture, e.g. `mips-linux-gnu-`  
+`SIMULATION` - Define it to build with SDL for running on your local machine.  
+`ZBOLT` - Define it to use the Z-Bolt icon set. By default the build uses the Material Design Icons.  
 `GUPPYSCREEN_VERSION` - Version string displayed in the System Panel in the UI.
 
 ### Build Environment


### PR DESCRIPTION
Added spaces to the end of the lines to make each variable appear on its own line.