### PR TITLE
Major rework: tick bug fix, restore state after movement, temperature fan support, UI updates, and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 *.o
 *.a
 /.idea
+/.vscode

--- a/src/bedmesh_panel.cpp
+++ b/src/bedmesh_panel.cpp
@@ -22,7 +22,7 @@ BedMeshPanel::BedMeshPanel(KWebSocketClient &c, std::mutex &l)
   , prompt(lv_obj_create(lv_scr_act()))
   , top_cont(lv_obj_create(cont))
   , mesh_table(lv_table_create(top_cont))
-  , profile_cont(lv_table_create(top_cont))
+  , profile_cont(lv_obj_create(top_cont))
   , profile_table(lv_table_create(profile_cont))
   , profile_info(lv_table_create(profile_cont))
   , controls_cont(lv_obj_create(cont))
@@ -35,19 +35,18 @@ BedMeshPanel::BedMeshPanel(KWebSocketClient &c, std::mutex &l)
   , kb(lv_keyboard_create(prompt))
 {
   lv_obj_move_background(cont);
-  
+
   lv_obj_set_size(cont, LV_PCT(100), LV_PCT(100));
-  lv_obj_set_style_pad_all(cont, 0, 0);
-  lv_obj_set_style_pad_row(cont, 0, 0);
-  
   lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_COLUMN);
-  lv_obj_set_flex_grow(top_cont, 1);
+  lv_obj_set_flex_align(cont, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
 
-  lv_obj_set_flex_align(top_cont, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
   lv_obj_set_width(top_cont, LV_PCT(100));
   lv_obj_clear_flag(top_cont, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_flex_flow(top_cont, LV_FLEX_FLOW_ROW);
+  lv_obj_set_flex_align(top_cont, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+  lv_obj_set_flex_grow(top_cont, 1);
+  lv_obj_set_style_pad_all(top_cont, 0, 0);
 
   auto screen_width = lv_disp_get_physical_hor_res(NULL);
   if (screen_width < 800) {
@@ -55,35 +54,61 @@ BedMeshPanel::BedMeshPanel(KWebSocketClient &c, std::mutex &l)
   } else {
     lv_obj_set_style_text_font(mesh_table, &lv_font_montserrat_10, LV_STATE_DEFAULT);
   }
-  auto scale = (double)screen_width / 800.0;
-  auto hscale = (double)lv_disp_get_physical_ver_res(NULL) / 480.0;
-  
-  lv_obj_set_size(profile_cont, LV_PCT(50), 340 * hscale);
-  lv_obj_set_style_pad_all(profile_cont, 0, 0);
-  lv_obj_set_style_border_width(profile_cont, 0, 0);  
+
+  // mesh table
+  lv_obj_set_height(mesh_table, LV_PCT(100));
+  lv_obj_clear_flag(mesh_table, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_flex_grow(mesh_table, 1);
+
+  // profile container
+  lv_obj_set_height(profile_cont, LV_PCT(100));
   lv_obj_clear_flag(profile_cont, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_flex_flow(profile_cont, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_align(profile_cont, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+  lv_obj_set_flex_grow(profile_cont, 1);
+  lv_obj_set_style_pad_all(profile_cont, 0, 0);
 
   // profile table
-  lv_table_set_col_width(profile_table, 0, 260 * scale);
-  lv_table_set_col_width(profile_table, 1, 50 * scale);
-  lv_table_set_col_width(profile_table, 2, 50 * scale);
-  lv_obj_set_height(profile_table, 200 * hscale);
+  lv_obj_add_event_cb(profile_cont, [](lv_event_t *e) {
+    lv_obj_t *profile_cont = lv_event_get_target(e);
+    lv_obj_t *profile_table = static_cast<lv_obj_t *>(lv_event_get_user_data(e));
+
+    int profile_cont_width = lv_obj_get_width(profile_cont);
+
+    lv_table_set_col_width(profile_table, 0, profile_cont_width * 0.7);
+    lv_table_set_col_width(profile_table, 1, profile_cont_width * 0.15);
+    lv_table_set_col_width(profile_table, 2, profile_cont_width * 0.15);
+    }, LV_EVENT_SIZE_CHANGED, profile_table);
+  lv_obj_set_flex_grow(profile_table, 1);
+  lv_obj_set_style_pad_all(profile_table, 0, 0);
 
   // profile info
-  lv_table_set_col_width(profile_info, 0, 240 * scale);
-  lv_table_set_col_width(profile_info, 1, 120 * scale);
-  lv_obj_set_height(profile_info, 150 * hscale);
-  lv_obj_set_style_pad_top(profile_info, 5, LV_PART_ITEMS | LV_STATE_DEFAULT);
-  lv_obj_set_style_pad_bottom(profile_info, 5, LV_PART_ITEMS | LV_STATE_DEFAULT);
-  lv_obj_set_style_border_side(profile_info, LV_BORDER_SIDE_BOTTOM, 0);
+  lv_obj_add_event_cb(profile_cont, [](lv_event_t *e) {
+    lv_obj_t *profile_cont = lv_event_get_target(e);
+    lv_obj_t *profile_info = static_cast<lv_obj_t *>(lv_event_get_user_data(e));
+
+    int profile_cont_width = lv_obj_get_width(profile_cont);
+
+    lv_table_set_col_width(profile_info, 0, profile_cont_width * 0.5);
+    lv_table_set_col_width(profile_info, 1, profile_cont_width * 0.5);
+    }, LV_EVENT_SIZE_CHANGED, profile_info);
+  lv_obj_set_flex_grow(profile_info, 1);
+  lv_obj_set_style_pad_all(profile_info, 0, 0);
+  lv_obj_set_style_pad_top(profile_info, 2, LV_PART_ITEMS | LV_STATE_DEFAULT);
+  lv_obj_set_style_pad_bottom(profile_info, 2, LV_PART_ITEMS | LV_STATE_DEFAULT);
 
   // button controls
-  lv_obj_set_width(controls_cont, LV_PCT(100));
+  lv_obj_set_size(controls_cont, LV_PCT(100), LV_SIZE_CONTENT);
   lv_obj_set_flex_align(controls_cont, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER);
   lv_obj_set_flex_flow(controls_cont, LV_FLEX_FLOW_ROW);
   lv_obj_clear_flag(controls_cont, LV_OBJ_FLAG_SCROLLABLE);
- 
+  lv_obj_set_style_pad_all(controls_cont, 0, 0);
+
+  lv_obj_set_flex_grow(save_btn.get_container(), 1);
+  lv_obj_set_flex_grow(clear_btn.get_container(), 1);
+  lv_obj_set_flex_grow(calibrate_btn.get_container(), 1);
+  lv_obj_set_flex_grow(back_btn.get_container(), 1);
+
   lv_obj_add_event_cb(mesh_table, &BedMeshPanel::_mesh_draw_cb, LV_EVENT_DRAW_PART_BEGIN, this);
   lv_obj_add_event_cb(profile_table, &BedMeshPanel::_handle_profile_action, LV_EVENT_VALUE_CHANGED, this);
 
@@ -91,17 +116,17 @@ BedMeshPanel::BedMeshPanel(KWebSocketClient &c, std::mutex &l)
   lv_obj_set_style_pad_all(prompt, 0, 0);
   lv_obj_set_size(prompt, LV_PCT(100), LV_PCT(100));
   lv_obj_clear_flag(prompt, LV_OBJ_FLAG_SCROLLABLE);
-  lv_obj_add_flag(prompt, LV_OBJ_FLAG_HIDDEN);  
+  lv_obj_add_flag(prompt, LV_OBJ_FLAG_HIDDEN);
   lv_obj_set_style_bg_opa(prompt, LV_OPA_70, 0);
 
   lv_textarea_set_one_line(input, true);
   lv_obj_set_width(input, LV_PCT(100));
-  
+
   // lv_obj_add_flag(kb, LV_OBJ_FLAG_HIDDEN);
   lv_obj_set_flex_flow(msgbox, LV_FLEX_FLOW_ROW_WRAP);
   lv_obj_set_flex_align(msgbox, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER);
   lv_obj_set_style_pad_row(msgbox, 25, 0);
-  
+
   lv_obj_clear_flag(msgbox, LV_OBJ_FLAG_SCROLLABLE);
 
   lv_obj_set_size(msgbox, LV_PCT(60), LV_PCT(40));
@@ -109,7 +134,7 @@ BedMeshPanel::BedMeshPanel(KWebSocketClient &c, std::mutex &l)
   lv_obj_set_style_bg_color(msgbox, lv_palette_darken(LV_PALETTE_GREY, 1), 0);
   lv_obj_align(msgbox, LV_ALIGN_TOP_MID, 0, 20);
 
-  lv_obj_t * label = NULL;
+  lv_obj_t *label = NULL;
 
   label = lv_label_create(msgbox);
   lv_obj_set_width(label, LV_PCT(100));
@@ -152,7 +177,7 @@ BedMeshPanel::~BedMeshPanel() {
 void BedMeshPanel::consume(json &j) {
   auto bm = j["/params/0/bed_mesh"_json_pointer];
   if (!bm.is_null()) {
-    spdlog::trace("bedmesh panel consume {}",  bm["/profiles"_json_pointer].dump());
+    spdlog::trace("bedmesh panel consume {}", bm["/profiles"_json_pointer].dump());
     refresh_views_with_lock(bm);
   }
 }
@@ -162,11 +187,11 @@ void BedMeshPanel::refresh_views_with_lock(json &bm) {
   refresh_views(bm);
 }
 
-void BedMeshPanel::refresh_views(json &bm) {  
+void BedMeshPanel::refresh_views(json &bm) {
   if (!bm.is_null()) {
     auto active_profile_j = bm["/profile_name"_json_pointer];
     size_t row_idx = 0;
-    if(active_profile_j.is_null()) {
+    if (active_profile_j.is_null()) {
       save_btn.disable();
       return;
     }
@@ -177,39 +202,40 @@ void BedMeshPanel::refresh_views(json &bm) {
 
       refresh_profile_info(active_profile);
       lv_obj_clear_flag(mesh_table, LV_OBJ_FLAG_HIDDEN);
-      
+
       auto mesh_json = bm["/probed_matrix"_json_pointer];
       if (mesh_json.is_null()) {
-	mesh_json = State::get_instance()->get_data("/printer_state/bed_mesh/probed_matrix"_json_pointer);
+        mesh_json = State::get_instance()->get_data("/printer_state/bed_mesh/probed_matrix"_json_pointer);
       }
 
       mesh = mesh_json.template get<std::vector<std::vector<double>>>();
 
       // calculate cell width
       if (mesh.size() > 0 && mesh[0].size() > 0) {
-	auto scale = (double)lv_disp_get_physical_hor_res(NULL) / 800.0;
-	int col_width = std::max(4, (int)(380 * scale / mesh[0].size()));
-	int cel_height = std::max(1, (int)(col_width / 2 - 8));
+        auto height = lv_obj_get_height(mesh_table);
+        int cel_height = std::max(1, (int)(height / mesh.size() / 2 - 5));
+        auto width = lv_obj_get_width(mesh_table);
+        int col_width = std::max(4, (int)(width / mesh[0].size()));
 
-	lv_obj_set_style_pad_top(mesh_table, cel_height, LV_PART_ITEMS | LV_STATE_DEFAULT);
-	lv_obj_set_style_pad_bottom(mesh_table, cel_height, LV_PART_ITEMS | LV_STATE_DEFAULT);
+        lv_obj_set_style_pad_top(mesh_table, cel_height, LV_PART_ITEMS | LV_STATE_DEFAULT);
+        lv_obj_set_style_pad_bottom(mesh_table, cel_height, LV_PART_ITEMS | LV_STATE_DEFAULT);
 
-	lv_table_set_col_cnt(mesh_table, mesh[0].size());
-	for (int i = 0; i < mesh[0].size(); i++) {
-	  lv_table_set_col_width(mesh_table, i, col_width);
-	}
+        lv_table_set_col_cnt(mesh_table, mesh[0].size());
+        for (int i = 0; i < mesh[0].size(); i++) {
+          lv_table_set_col_width(mesh_table, i, col_width);
+        }
       }
 
       for (int i = mesh.size() - 1; i >= 0; i--) {
-	auto row = mesh[i];
-	for (int j = 0; j < row.size(); j++) {
-	  if (mesh.size() < 6 && row.size() < 6) {
-	    lv_table_set_cell_value(mesh_table, row_idx, j, fmt::format("{:.2f}", row[j]).c_str());
-	  } else {
-	    lv_table_set_cell_value(mesh_table, row_idx, j, "");
-	  }
-	}
-	row_idx++;
+        auto row = mesh[i];
+        for (int j = 0; j < row.size(); j++) {
+          if (mesh.size() < 6 && row.size() < 6) {
+            lv_table_set_cell_value(mesh_table, row_idx, j, fmt::format("{:.2f}", row[j]).c_str());
+          } else {
+            lv_table_set_cell_value(mesh_table, row_idx, j, "");
+          }
+        }
+        row_idx++;
       }
       lv_table_set_row_cnt(mesh_table, row_idx);
     } else {
@@ -228,34 +254,34 @@ void BedMeshPanel::refresh_views(json &bm) {
 
     if (profiles.size() > 0) {
       lv_obj_clear_flag(profile_cont, LV_OBJ_FLAG_HIDDEN);
-      
+
       row_idx = 0;
       for (auto &el : profiles.items()) {
-	lv_table_clear_cell_ctrl(profile_table, row_idx, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
-      
-	bool is_active = el.key() == active_profile;
-	if (is_active) {
-	  lv_table_add_cell_ctrl(profile_table, row_idx, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
-	  lv_table_set_cell_value(profile_table, row_idx, 1, "");
-	} else {
-	  lv_table_set_cell_value(profile_table, row_idx, 1, LV_SYMBOL_UPLOAD);
-	}
+        lv_table_clear_cell_ctrl(profile_table, row_idx, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
 
-	lv_table_set_cell_value(profile_table, row_idx, 0, el.key().c_str());
-	lv_table_set_cell_value(profile_table, row_idx, 2, LV_SYMBOL_CLOSE);
-	row_idx++;
+        bool is_active = el.key() == active_profile;
+        if (is_active) {
+          lv_table_add_cell_ctrl(profile_table, row_idx, 0, LV_TABLE_CELL_CTRL_MERGE_RIGHT);
+          lv_table_set_cell_value(profile_table, row_idx, 1, "");
+        } else {
+          lv_table_set_cell_value(profile_table, row_idx, 1, LV_SYMBOL_UPLOAD);
+        }
+
+        lv_table_set_cell_value(profile_table, row_idx, 0, el.key().c_str());
+        lv_table_set_cell_value(profile_table, row_idx, 2, LV_SYMBOL_CLOSE);
+        row_idx++;
       }
       lv_table_set_row_cnt(profile_table, row_idx);
     } else {
       // no profiles, hide profile table
-      lv_obj_add_flag(profile_cont, LV_OBJ_FLAG_HIDDEN);      
+      lv_obj_add_flag(profile_cont, LV_OBJ_FLAG_HIDDEN);
     }
-  }  
+  }
 }
 
 void BedMeshPanel::refresh_profile_info(std::string profile) {
   auto mesh_params = State::get_instance()->get_data(json::json_pointer(
-			fmt::format("/printer_state/bed_mesh/profiles/{}/mesh_params", profile)));
+    fmt::format("/printer_state/bed_mesh/profiles/{}/mesh_params", profile)));
   spdlog::trace("refreshing profile info {}, {}", profile, mesh_params.dump());
 
   if (!mesh_params.is_null()) {
@@ -272,25 +298,25 @@ void BedMeshPanel::refresh_profile_info(std::string profile) {
       lv_table_set_cell_value(profile_info, rowidx, 0, "Tension");
       lv_table_set_cell_value(profile_info, rowidx, 1, fmt::format("{}", v.template get<double>()).c_str());
       rowidx++;
-    }    
+    }
 
     std::vector<int> xvalues;
     for (auto &param : {"min_x", "max_x", "x_count", "mesh_x_pps"}) {
       v = mesh_params[json::json_pointer(fmt::format("/{}", param))];
       if (!v.is_null()) {
-	xvalues.push_back(v.template get<int>());
+        xvalues.push_back(v.template get<int>());
       }
     }
 
     lv_table_set_cell_value(profile_info, rowidx, 0, "X (min, max, count, pps)");
     lv_table_set_cell_value(profile_info, rowidx, 1, fmt::format("{}", fmt::join(xvalues, ", ")).c_str());
-    rowidx++;    
+    rowidx++;
 
     std::vector<int> yvalues;
     for (auto &param : {"min_y", "max_y", "y_count", "mesh_y_pps"}) {
       v = mesh_params[json::json_pointer(fmt::format("/{}", param))];
       if (!v.is_null()) {
-	yvalues.push_back(v.template get<int>());
+        yvalues.push_back(v.template get<int>());
       }
     }
 
@@ -304,7 +330,7 @@ void BedMeshPanel::foreground() {
   auto bm = State::get_instance()->get_data("/printer_state/bed_mesh"_json_pointer);
   spdlog::trace("bm {}", bm.dump());
   refresh_views(bm);
-  
+
   lv_obj_move_foreground(cont);
 }
 
@@ -318,21 +344,21 @@ void BedMeshPanel::handle_callback(lv_event_t *event) {
     if (active_profile.length() > 0) {
       lv_textarea_set_text(input, active_profile.c_str());
     }
-    
+
     lv_obj_move_foreground(prompt);
-    
+
   } else if (btn == clear_btn.get_container()) {
     spdlog::trace("mesh clear pressed");
     ws.gcode_script("BED_MESH_CLEAR");
-    
+
   } else if (btn == calibrate_btn.get_container()) {
     spdlog::trace("mesh calibrate pressed");
     auto v = State::get_instance()
       ->get_data("/printer_state/toolhead/homed_axes"_json_pointer);
     if (!v.is_null()) {
       if (v.template get<std::string>() == "xy") {
-	ws.gcode_script("BED_MESH_CALIBRATE");
-	return;
+        ws.gcode_script("BED_MESH_CALIBRATE");
+        return;
       }
     }
     ws.gcode_script("G28 X Y Z\nBED_MESH_CALIBRATE");
@@ -345,7 +371,7 @@ void BedMeshPanel::handle_callback(lv_event_t *event) {
 
 void BedMeshPanel::handle_profile_action(lv_event_t *e) {
   lv_event_code_t code = lv_event_get_code(e);
-  if(code == LV_EVENT_VALUE_CHANGED) {
+  if (code == LV_EVENT_VALUE_CHANGED) {
     uint16_t row;
     uint16_t col;
 
@@ -354,7 +380,7 @@ void BedMeshPanel::handle_profile_action(lv_event_t *e) {
     if (row == LV_TABLE_CELL_NONE || col == LV_TABLE_CELL_NONE || row >= row_count) {
       return;
     }
-    const char *selected = lv_table_get_cell_value(profile_table, row, col);    
+    const char *selected = lv_table_get_cell_value(profile_table, row, col);
     const char *profile_name = lv_table_get_cell_value(profile_table, row, 0);
     spdlog::trace("selected {}, {}, value {}", row, col, profile_name);
     if (col == 2) {
@@ -371,13 +397,13 @@ void BedMeshPanel::handle_profile_action(lv_event_t *e) {
     } else if (col == 0) {
       // display mesh info and refresh bed mesh matrix
     }
-      
+
   }
 }
 
 void BedMeshPanel::handle_prompt_save(lv_event_t *e) {
   lv_event_code_t code = lv_event_get_code(e);
-  if(code == LV_EVENT_CLICKED) {
+  if (code == LV_EVENT_CLICKED) {
     const char *profile_name = lv_textarea_get_text(input);
     if (profile_name == NULL || strlen(profile_name) == 0) {
       return;
@@ -386,15 +412,15 @@ void BedMeshPanel::handle_prompt_save(lv_event_t *e) {
     ws.gcode_script(fmt::format("BED_MESH_PROFILE SAVE=\"{}\"\nSAVE_CONFIG", profile_name));
 
     lv_textarea_set_text(input, "");
-    lv_obj_add_flag(prompt, LV_OBJ_FLAG_HIDDEN);  
+    lv_obj_add_flag(prompt, LV_OBJ_FLAG_HIDDEN);
     lv_obj_move_background(prompt);
-  }  
+  }
 }
 
 void BedMeshPanel::handle_prompt_cancel(lv_event_t *e) {
   lv_event_code_t code = lv_event_get_code(e);
-  if(code == LV_EVENT_CLICKED) {
-    lv_obj_add_flag(prompt, LV_OBJ_FLAG_HIDDEN);  
+  if (code == LV_EVENT_CLICKED) {
+    lv_obj_add_flag(prompt, LV_OBJ_FLAG_HIDDEN);
     lv_obj_move_background(prompt);
   }
 }
@@ -412,22 +438,22 @@ void BedMeshPanel::handle_kb_input(lv_event_t *e)
     ws.gcode_script(fmt::format("BED_MESH_PROFILE SAVE=\"{}\"\nSAVE_CONFIG", profile_name));
 
     lv_textarea_set_text(input, "");
-    lv_obj_add_flag(prompt, LV_OBJ_FLAG_HIDDEN);  
+    lv_obj_add_flag(prompt, LV_OBJ_FLAG_HIDDEN);
     lv_obj_move_background(prompt);
   }
 }
 
-void BedMeshPanel::mesh_draw_cb(lv_event_t * e)
+void BedMeshPanel::mesh_draw_cb(lv_event_t *e)
 {
-  lv_obj_t * obj = lv_event_get_target(e);
-  lv_obj_draw_part_dsc_t * dsc = lv_event_get_draw_part_dsc(e);
-  if(dsc->part == LV_PART_ITEMS && !mesh.empty()) {
-    uint32_t row = dsc->id /  lv_table_get_col_cnt(obj);
+  lv_obj_t *obj = lv_event_get_target(e);
+  lv_obj_draw_part_dsc_t *dsc = lv_event_get_draw_part_dsc(e);
+  if (dsc->part == LV_PART_ITEMS && !mesh.empty()) {
+    uint32_t row = dsc->id / lv_table_get_col_cnt(obj);
     uint32_t col = dsc->id - row * lv_table_get_col_cnt(obj);
 
     dsc->label_dsc->align = LV_TEXT_ALIGN_CENTER;
     dsc->label_dsc->color = lv_palette_darken(LV_PALETTE_GREY, 3);
-    
+
     // rows of the mesh is reversed
     int32_t reversed_row_idx = mesh.size() - row - 1;
     double offset = mesh[reversed_row_idx][col];
@@ -446,9 +472,9 @@ static lv_color_t color_gradient(double offset)
     return lv_color_make(255, color, color);
   }
 
-  if (offset < 0 ) {
+  if (offset < 0) {
     return lv_color_make(color, color, 255);
   }
-  
+
   return lv_color_make(255, 255, 255);
 }

--- a/src/belts_calibration_panel.cpp
+++ b/src/belts_calibration_panel.cpp
@@ -32,11 +32,11 @@ BeltsCalibrationPanel::BeltsCalibrationPanel(KWebSocketClient &c, std::mutex &l)
   , calibrate_btn(button_cont, &resume, "Shake Belts", &BeltsCalibrationPanel::_handle_callback, this)
   , excite_btn(button_cont, &inputshaper_img, "Excitate", &BeltsCalibrationPanel::_handle_callback, this)
   , emergency_btn(button_cont, &emergency, "Stop", &BeltsCalibrationPanel::_handle_callback, this,
-		  "Do you want to emergency stop?",
-		  [&c]() {
-		    spdlog::debug("emergency stop pressed");
-		    c.send_jsonrpc("printer.emergency_stop");
-		  })
+    "Do you want to emergency stop?",
+    [&c]() {
+      spdlog::debug("emergency stop pressed");
+      c.send_jsonrpc("printer.emergency_stop");
+    })
   , back_btn(button_cont, &back, "Back", &BeltsCalibrationPanel::_handle_callback, this)
   , image_fullsized(false)
 {
@@ -50,7 +50,7 @@ BeltsCalibrationPanel::BeltsCalibrationPanel(KWebSocketClient &c, std::mutex &l)
   lv_obj_add_flag(graph_cont, LV_OBJ_FLAG_CLICKABLE);
   lv_obj_clear_flag(graph_cont, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_add_event_cb(graph_cont, &BeltsCalibrationPanel::_handle_image_clicked,
-		      LV_EVENT_CLICKED, this);
+    LV_EVENT_CLICKED, this);
   lv_obj_set_size(graph_cont, LV_PCT(50), LV_PCT(50));
 
   lv_img_set_zoom(graph, 100);
@@ -75,7 +75,7 @@ BeltsCalibrationPanel::BeltsCalibrationPanel(KWebSocketClient &c, std::mutex &l)
   lv_slider_set_range(excite_slider, 10, 1400);
 
   lv_obj_add_event_cb(excite_slider, &BeltsCalibrationPanel::_handle_update_slider,
-		      LV_EVENT_VALUE_CHANGED, this);
+    LV_EVENT_VALUE_CHANGED, this);
 
   lv_obj_align_to(excite_label, excite_slider, LV_ALIGN_BOTTOM_MID, 0, 35 * hscale);
   lv_label_set_text(excite_label, "1 hz");
@@ -104,8 +104,8 @@ BeltsCalibrationPanel::BeltsCalibrationPanel(KWebSocketClient &c, std::mutex &l)
   lv_obj_set_grid_cell(button_cont, LV_GRID_ALIGN_CENTER, 0, 1, LV_GRID_ALIGN_CENTER, 2, 1);
 
   ws.register_method_callback("notify_gcode_response",
-			      "BeltsCalibrationPanel",
-			      [this](json& d) { this->handle_macro_response(d); });
+    "BeltsCalibrationPanel",
+    [this](json &d) { this->handle_macro_response(d); });
 
 }
 
@@ -124,7 +124,7 @@ void BeltsCalibrationPanel::handle_callback(lv_event_t *event) {
   lv_obj_t *btn = lv_event_get_current_target(event);
   if (btn == calibrate_btn.get_container()) {
     auto config_root = KUtils::get_root_path("config");
-    auto png_path = fmt::format("{}/{}", config_root.length() > 0 ? config_root : "/tmp" , BELTS_PNG);
+    auto png_path = fmt::format("{}/{}", config_root.length() > 0 ? config_root : "/tmp", BELTS_PNG);
 
     if (!KUtils::is_homed()) {
       ws.gcode_script("G28");
@@ -133,7 +133,7 @@ void BeltsCalibrationPanel::handle_callback(lv_event_t *event) {
     auto screen_width = (double)lv_disp_get_physical_hor_res(NULL) / 100.0;
     auto screen_height = (double)lv_disp_get_physical_ver_res(NULL) / 100.0;
     ws.gcode_script(fmt::format("GUPPY_BELTS_SHAPER_CALIBRATION PNG_OUT_PATH={} PNG_WIDTH={} PNG_HEIGHT={}",
-				png_path, screen_width, screen_height));
+      png_path, screen_width, screen_height));
 
     // ws.gcode_script(fmt::format("GUPPY_BELTS_SHAPER_CALIBRATION PNG_OUT_PATH={} PNG_WIDTH={} PNG_HEIGHT={} FREQ_START=5 FREQ_END=10",
     // 				png_path, screen_width, screen_height));
@@ -169,14 +169,14 @@ void BeltsCalibrationPanel::handle_image_clicked(lv_event_t *e) {
 
     if (clicked == graph_cont) {
       if (image_fullsized) {
-	lv_img_set_zoom(graph, 100);
-	lv_obj_set_size(graph_cont, LV_PCT(50), LV_PCT(50));
-	lv_obj_clear_flag(graph_cont, LV_OBJ_FLAG_FLOATING);
+        lv_img_set_zoom(graph, 100);
+        lv_obj_set_size(graph_cont, LV_PCT(50), LV_PCT(50));
+        lv_obj_clear_flag(graph_cont, LV_OBJ_FLAG_FLOATING);
 
       } else {
-	lv_img_set_zoom(graph, LV_IMG_ZOOM_NONE);
-	lv_obj_set_size(graph_cont, LV_PCT(100), LV_PCT(100));
-	lv_obj_add_flag(graph_cont, LV_OBJ_FLAG_FLOATING);
+        lv_img_set_zoom(graph, LV_IMG_ZOOM_NONE);
+        lv_obj_set_size(graph_cont, LV_PCT(100), LV_PCT(100));
+        lv_obj_add_flag(graph_cont, LV_OBJ_FLAG_FLOATING);
       }
       lv_obj_move_foreground(graph_cont);
       image_fullsized = !image_fullsized;
@@ -193,12 +193,12 @@ void BeltsCalibrationPanel::handle_macro_response(json &j) {
     if (resp.rfind("// Command {guppy_belts_calibration} finished", 0) == 0) {
       spdlog::trace("belts calbiration finished");
       auto config_root = KUtils::get_root_path("config");
-      auto png_path = fmt::format("{}/{}", config_root.length() > 0 ? config_root : "/tmp" , BELTS_PNG);
+      auto png_path = fmt::format("{}/{}", config_root.length() > 0 ? config_root : "/tmp", BELTS_PNG);
 
       png_path =
-	fmt::format("A:{}", KUtils::is_running_local()
-		    ? png_path
-		    : KUtils::download_file("config", BELTS_PNG, Config::get_instance()->get_thumbnail_path()));
+        fmt::format("A:{}", KUtils::is_running_local()
+          ? png_path
+          : KUtils::download_file("config", BELTS_PNG, Config::get_instance()->get_thumbnail_path()));
 
       lv_img_set_src(graph, png_path.c_str());
       lv_obj_clear_flag(graph, LV_OBJ_FLAG_HIDDEN);
@@ -213,6 +213,6 @@ void BeltsCalibrationPanel::handle_update_slider(lv_event_t *e) {
   if (code == LV_EVENT_VALUE_CHANGED) {
     double hz = (double)lv_slider_get_value(excite_slider);
     lv_slider_set_value(excite_slider, hz, LV_ANIM_OFF);
-    lv_label_set_text(excite_label, fmt::format("{} hz", hz / 10.0 ).c_str());
+    lv_label_set_text(excite_label, fmt::format("{} hz", hz / 10.0).c_str());
   }
 }

--- a/src/belts_calibration_panel.cpp
+++ b/src/belts_calibration_panel.cpp
@@ -76,10 +76,10 @@ BeltsCalibrationPanel::BeltsCalibrationPanel(KWebSocketClient &c, std::mutex &l)
 
   lv_obj_add_event_cb(excite_slider, &BeltsCalibrationPanel::_handle_update_slider,
 		      LV_EVENT_VALUE_CHANGED, this);
-  
+
   lv_obj_align_to(excite_label, excite_slider, LV_ALIGN_BOTTOM_MID, 0, 35 * hscale);
   lv_label_set_text(excite_label, "1 hz");
-  
+
   lv_dropdown_set_options(excite_dd, fmt::format("{}", fmt::join(axes, "\n")).c_str());
   lv_obj_align(excite_dd, LV_ALIGN_RIGHT_MID, 0, 0);
 
@@ -87,9 +87,14 @@ BeltsCalibrationPanel::BeltsCalibrationPanel(KWebSocketClient &c, std::mutex &l)
   lv_obj_set_flex_align(button_cont, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
   lv_obj_set_size(button_cont, LV_PCT(100), LV_SIZE_CONTENT);
 
+  lv_obj_set_flex_grow(calibrate_btn.get_container(), 1);
+  lv_obj_set_flex_grow(excite_btn.get_container(), 1);
+  lv_obj_set_flex_grow(emergency_btn.get_container(), 1);
+  lv_obj_set_flex_grow(back_btn.get_container(), 1);
+
   static lv_coord_t grid_main_row_dsc[] = {LV_GRID_FR(4), LV_GRID_FR(1), LV_GRID_FR(2), LV_GRID_TEMPLATE_LAST};
   static lv_coord_t grid_main_col_dsc[] = {LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
-  
+
   lv_obj_set_grid_dsc_array(cont, grid_main_col_dsc, grid_main_row_dsc);
 
   lv_obj_set_grid_cell(graph_cont, LV_GRID_ALIGN_CENTER, 0, 1, LV_GRID_ALIGN_START, 0, 1);
@@ -101,7 +106,7 @@ BeltsCalibrationPanel::BeltsCalibrationPanel(KWebSocketClient &c, std::mutex &l)
   ws.register_method_callback("notify_gcode_response",
 			      "BeltsCalibrationPanel",
 			      [this](json& d) { this->handle_macro_response(d); });
-  
+
 }
 
 BeltsCalibrationPanel::~BeltsCalibrationPanel() {
@@ -132,10 +137,10 @@ void BeltsCalibrationPanel::handle_callback(lv_event_t *event) {
 
     // ws.gcode_script(fmt::format("GUPPY_BELTS_SHAPER_CALIBRATION PNG_OUT_PATH={} PNG_WIDTH={} PNG_HEIGHT={} FREQ_START=5 FREQ_END=10",
     // 				png_path, screen_width, screen_height));
-    
+
 
     lv_obj_add_flag(graph, LV_OBJ_FLAG_HIDDEN);
-    lv_img_set_src(graph, NULL);    
+    lv_img_set_src(graph, NULL);
     lv_obj_invalidate(graph);
     lv_obj_clear_flag(spinner, LV_OBJ_FLAG_HIDDEN);
     lv_obj_move_foreground(spinner);
@@ -166,16 +171,16 @@ void BeltsCalibrationPanel::handle_image_clicked(lv_event_t *e) {
       if (image_fullsized) {
 	lv_img_set_zoom(graph, 100);
 	lv_obj_set_size(graph_cont, LV_PCT(50), LV_PCT(50));
-	lv_obj_clear_flag(graph_cont, LV_OBJ_FLAG_FLOATING);	
-	
+	lv_obj_clear_flag(graph_cont, LV_OBJ_FLAG_FLOATING);
+
       } else {
 	lv_img_set_zoom(graph, LV_IMG_ZOOM_NONE);
 	lv_obj_set_size(graph_cont, LV_PCT(100), LV_PCT(100));
 	lv_obj_add_flag(graph_cont, LV_OBJ_FLAG_FLOATING);
       }
-      lv_obj_move_foreground(graph_cont);      
+      lv_obj_move_foreground(graph_cont);
       image_fullsized = !image_fullsized;
-    } 
+    }
   }
 }
 
@@ -190,7 +195,7 @@ void BeltsCalibrationPanel::handle_macro_response(json &j) {
       auto config_root = KUtils::get_root_path("config");
       auto png_path = fmt::format("{}/{}", config_root.length() > 0 ? config_root : "/tmp" , BELTS_PNG);
 
-      png_path = 
+      png_path =
 	fmt::format("A:{}", KUtils::is_running_local()
 		    ? png_path
 		    : KUtils::download_file("config", BELTS_PNG, Config::get_instance()->get_thumbnail_path()));

--- a/src/button_container.cpp
+++ b/src/button_container.cpp
@@ -3,12 +3,12 @@
 #include "spdlog/spdlog.h"
 
 ButtonContainer::ButtonContainer(lv_obj_t *parent,
-				 const void *btn_img,
-				 const char *text,
-				 lv_event_cb_t cb,
-				 void* user_data,
-				 const std::string &prompt,
-				 const std::function<void()> &pcb)
+         const void *btn_img,
+         const char *text,
+         lv_event_cb_t cb,
+         void* user_data,
+         const std::string &prompt,
+         const std::function<void()> &pcb)
   : btn_cont(lv_obj_create(parent))
   , btn(lv_imgbtn_create(btn_cont))
   , label(lv_label_create(btn_cont))
@@ -16,15 +16,21 @@ ButtonContainer::ButtonContainer(lv_obj_t *parent,
   , prompt_callback(pcb)
 {
   lv_obj_set_style_pad_all(btn_cont, 0, 0);
+  lv_obj_set_style_pad_row(btn_cont, 0, 0);
+  lv_obj_set_style_pad_bottom(btn_cont, 5, 0);
   auto width_scale = (double)lv_disp_get_physical_hor_res(NULL) / 800.0;
-  lv_obj_set_size(btn_cont, 150 * width_scale, LV_SIZE_CONTENT);
-
+  lv_obj_set_size(btn_cont, 110 * width_scale, LV_SIZE_CONTENT);
+  lv_obj_set_style_radius(btn_cont, 10 * width_scale, 0);
+  lv_obj_set_style_border_width(btn_cont, 2, 0);
+  lv_obj_set_style_border_color(btn_cont, lv_palette_darken(LV_PALETTE_GREY, 3), 0);
+  lv_obj_set_flex_flow(btn_cont, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_align(btn_cont, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
   lv_obj_clear_flag(btn_cont, LV_OBJ_FLAG_SCROLLABLE);
   // lv_obj_add_style(btn_cont, &style, LV_PART_MAIN);
   lv_imgbtn_set_src(btn, LV_IMGBTN_STATE_RELEASED, NULL, btn_img, NULL);
   lv_obj_set_width(btn, LV_SIZE_CONTENT);
   // lv_obj_align(btn, LV_ALIGN_CENTER, 0, 0);
-  lv_obj_align(btn, LV_ALIGN_TOP_MID, 0, 0);
+  // lv_obj_align(btn, LV_ALIGN_TOP_MID, 0, 0);
 
   lv_obj_add_flag(btn, LV_OBJ_FLAG_EVENT_BUBBLE);
   // lv_obj_add_flag(btn_cont, LV_OBJ_FLAG_EVENT_BUBBLE);
@@ -36,31 +42,31 @@ ButtonContainer::ButtonContainer(lv_obj_t *parent,
   if (cb != NULL && !pcb) {
     lv_obj_add_event_cb(btn_cont, &ButtonContainer::_handle_callback, LV_EVENT_PRESSED, this);
     lv_obj_add_event_cb(btn_cont, &ButtonContainer::_handle_callback, LV_EVENT_RELEASED, this);
-    
+
     lv_obj_add_event_cb(btn_cont, cb, LV_EVENT_CLICKED, user_data);
   }
   else if (cb != NULL && pcb) {
     if (prompt_estop) {
       lv_obj_add_event_cb(btn_cont, [](lv_event_t *e) {
-	lv_event_code_t code = lv_event_get_code(e);
-	if (code == LV_EVENT_CLICKED) {
-	  ((ButtonContainer*)e->user_data)->handle_prompt();
-	}
+  lv_event_code_t code = lv_event_get_code(e);
+  if (code == LV_EVENT_CLICKED) {
+    ((ButtonContainer*)e->user_data)->handle_prompt();
+  }
       }, LV_EVENT_CLICKED, this);
     } else {
       lv_obj_add_event_cb(btn_cont, &ButtonContainer::_handle_callback, LV_EVENT_PRESSED, this);
       lv_obj_add_event_cb(btn_cont, &ButtonContainer::_handle_callback, LV_EVENT_RELEASED, this);
-    
+
       lv_obj_add_event_cb(btn_cont, cb, LV_EVENT_CLICKED, user_data);
     }
   }
 
   lv_label_set_text(label, text);
-  lv_obj_set_width(label, LV_PCT(100));
+  lv_obj_set_size(label, LV_PCT(100), LV_SIZE_CONTENT);
   lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_set_style_text_color(label, lv_palette_darken(LV_PALETTE_GREY, 1), LV_STATE_DISABLED);
 
-  lv_obj_align_to(label, btn, LV_ALIGN_OUT_BOTTOM_MID, 0, 0);
+  // lv_obj_align_to(label, btn, LV_ALIGN_OUT_BOTTOM_MID, 0, 0);
   // lv_obj_align(label, LV_ALIGN_BOTTOM_MID, 0, 5);
   // lv_obj_set_style_border_width(btn_cont, 2, 0);
 }
@@ -80,7 +86,7 @@ void ButtonContainer::disable() {
   lv_obj_add_state(btn, LV_STATE_DISABLED);
   lv_obj_add_state(btn_cont, LV_STATE_DISABLED);
   lv_obj_add_state(label, LV_STATE_DISABLED);
-  
+
 }
 
 void ButtonContainer::enable() {
@@ -111,16 +117,16 @@ void ButtonContainer::handle_prompt() {
 
   lv_obj_t *mbox1 = lv_msgbox_create(NULL, NULL, prompt_text.c_str(), btns, false);
   lv_obj_t *msg = ((lv_msgbox_t*)mbox1)->text;
-  lv_obj_set_style_text_align(msg, LV_TEXT_ALIGN_CENTER, 0);  
+  lv_obj_set_style_text_align(msg, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_set_width(msg, LV_PCT(100));
   lv_obj_center(msg);
-  
+
   lv_obj_t *btnm = lv_msgbox_get_btns(mbox1);
   lv_btnmatrix_set_btn_ctrl(btnm, 0, LV_BTNMATRIX_CTRL_CHECKED);
   lv_btnmatrix_set_btn_ctrl(btnm, 1, LV_BTNMATRIX_CTRL_CHECKED);
   lv_obj_add_flag(btnm, LV_OBJ_FLAG_FLOATING);
   lv_obj_align(btnm, LV_ALIGN_BOTTOM_MID, 0, 0);
-  
+
   auto hscale = (double)lv_disp_get_physical_ver_res(NULL) / 480.0;
 
   lv_obj_set_size(btnm, LV_PCT(90), 50 *hscale);
@@ -132,7 +138,7 @@ void ButtonContainer::handle_prompt() {
     if(clicked_btn == 0) {
       ((ButtonContainer*)e->user_data)->run_callback();
     }
-    
+
     lv_msgbox_close(obj);
 
   }, LV_EVENT_VALUE_CHANGED, this);

--- a/src/button_container.cpp
+++ b/src/button_container.cpp
@@ -3,12 +3,12 @@
 #include "spdlog/spdlog.h"
 
 ButtonContainer::ButtonContainer(lv_obj_t *parent,
-         const void *btn_img,
-         const char *text,
-         lv_event_cb_t cb,
-         void* user_data,
-         const std::string &prompt,
-         const std::function<void()> &pcb)
+  const void *btn_img,
+  const char *text,
+  lv_event_cb_t cb,
+  void *user_data,
+  const std::string &prompt,
+  const std::function<void()> &pcb)
   : btn_cont(lv_obj_create(parent))
   , btn(lv_imgbtn_create(btn_cont))
   , label(lv_label_create(btn_cont))
@@ -44,15 +44,14 @@ ButtonContainer::ButtonContainer(lv_obj_t *parent,
     lv_obj_add_event_cb(btn_cont, &ButtonContainer::_handle_callback, LV_EVENT_RELEASED, this);
 
     lv_obj_add_event_cb(btn_cont, cb, LV_EVENT_CLICKED, user_data);
-  }
-  else if (cb != NULL && pcb) {
+  } else if (cb != NULL && pcb) {
     if (prompt_estop) {
       lv_obj_add_event_cb(btn_cont, [](lv_event_t *e) {
-  lv_event_code_t code = lv_event_get_code(e);
-  if (code == LV_EVENT_CLICKED) {
-    ((ButtonContainer*)e->user_data)->handle_prompt();
-  }
-      }, LV_EVENT_CLICKED, this);
+        lv_event_code_t code = lv_event_get_code(e);
+        if (code == LV_EVENT_CLICKED) {
+          ((ButtonContainer *)e->user_data)->handle_prompt();
+        }
+        }, LV_EVENT_CLICKED, this);
     } else {
       lv_obj_add_event_cb(btn_cont, &ButtonContainer::_handle_callback, LV_EVENT_PRESSED, this);
       lv_obj_add_event_cb(btn_cont, &ButtonContainer::_handle_callback, LV_EVENT_RELEASED, this);
@@ -113,10 +112,10 @@ void ButtonContainer::handle_callback(lv_event_t *e) {
 }
 
 void ButtonContainer::handle_prompt() {
-  static const char * btns[] = {"Confirm", "Cancel", ""};
+  static const char *btns[] = {"Confirm", "Cancel", ""};
 
   lv_obj_t *mbox1 = lv_msgbox_create(NULL, NULL, prompt_text.c_str(), btns, false);
-  lv_obj_t *msg = ((lv_msgbox_t*)mbox1)->text;
+  lv_obj_t *msg = ((lv_msgbox_t *)mbox1)->text;
   lv_obj_set_style_text_align(msg, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_set_width(msg, LV_PCT(100));
   lv_obj_center(msg);
@@ -129,19 +128,19 @@ void ButtonContainer::handle_prompt() {
 
   auto hscale = (double)lv_disp_get_physical_ver_res(NULL) / 480.0;
 
-  lv_obj_set_size(btnm, LV_PCT(90), 50 *hscale);
+  lv_obj_set_size(btnm, LV_PCT(90), 50 * hscale);
   lv_obj_set_size(mbox1, LV_PCT(50), LV_PCT(35));
 
   lv_obj_add_event_cb(mbox1, [](lv_event_t *e) {
     lv_obj_t *obj = lv_obj_get_parent(lv_event_get_target(e));
     uint32_t clicked_btn = lv_msgbox_get_active_btn(obj);
-    if(clicked_btn == 0) {
-      ((ButtonContainer*)e->user_data)->run_callback();
+    if (clicked_btn == 0) {
+      ((ButtonContainer *)e->user_data)->run_callback();
     }
 
     lv_msgbox_close(obj);
 
-  }, LV_EVENT_VALUE_CHANGED, this);
+    }, LV_EVENT_VALUE_CHANGED, this);
 
   lv_obj_center(mbox1);
 }

--- a/src/extruder_panel.cpp
+++ b/src/extruder_panel.cpp
@@ -63,32 +63,40 @@ ExtruderPanel::ExtruderPanel(KWebSocketClient &websocket_client,
   }
 
   lv_obj_move_background(panel_cont);
-  lv_obj_clear_flag(panel_cont, LV_OBJ_FLAG_SCROLLABLE);  
+  lv_obj_clear_flag(panel_cont, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_size(panel_cont, LV_PCT(100), LV_PCT(100));
   lv_obj_set_style_pad_all(panel_cont, 0, 0);
 
-  lv_obj_set_size(rightside_btns_cont, LV_PCT(20), LV_PCT(100));  
+  lv_obj_set_size(rightside_btns_cont, LV_PCT(20), LV_PCT(100));
   lv_obj_set_flex_flow(rightside_btns_cont, LV_FLEX_FLOW_COLUMN);
-  lv_obj_set_flex_align(rightside_btns_cont, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+  lv_obj_set_flex_align(rightside_btns_cont, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
   lv_obj_clear_flag(rightside_btns_cont, LV_OBJ_FLAG_SCROLLABLE);
 
-  lv_obj_set_size(leftside_btns_cont, LV_PCT(20), LV_SIZE_CONTENT);
-  lv_obj_set_style_pad_row(leftside_btns_cont, 15, 0);
+  lv_obj_set_size(leftside_btns_cont, LV_PCT(20), LV_PCT(100));
+  // lv_obj_set_style_pad_row(leftside_btns_cont, 15, 0);
   lv_obj_set_flex_flow(leftside_btns_cont, LV_FLEX_FLOW_COLUMN);
-  lv_obj_set_flex_align(leftside_btns_cont, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+  lv_obj_set_flex_align(leftside_btns_cont, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
   lv_obj_clear_flag(leftside_btns_cont, LV_OBJ_FLAG_SCROLLABLE);
-  
-  spoolman_btn.disable();  
+
+  lv_obj_set_flex_grow(load_btn.get_container(), 1);
+  lv_obj_set_flex_grow(unload_btn.get_container(), 1);
+  lv_obj_set_flex_grow(cooldown_btn.get_container(), 1);
+  lv_obj_set_flex_grow(spoolman_btn.get_container(), 1);
+  lv_obj_set_flex_grow(extrude_btn.get_container(), 1);
+  lv_obj_set_flex_grow(retract_btn.get_container(), 1);
+  lv_obj_set_flex_grow(back_btn.get_container(), 1);
+
+  spoolman_btn.disable();
 
   static lv_coord_t grid_main_row_dsc[] = {LV_GRID_FR(3), LV_GRID_FR(6), LV_GRID_FR(6), LV_GRID_FR(6),
     LV_GRID_TEMPLATE_LAST};
   static lv_coord_t grid_main_col_dsc[] = {LV_GRID_FR(2), LV_GRID_FR(7), LV_GRID_FR(2), LV_GRID_TEMPLATE_LAST};
-  
+
   lv_obj_clear_flag(panel_cont, LV_OBJ_FLAG_SCROLLABLE);
-  
+
   lv_obj_set_grid_dsc_array(panel_cont, grid_main_col_dsc, grid_main_row_dsc);
   lv_obj_add_flag(extruder_temp.get_sensor(), LV_OBJ_FLAG_FLOATING);
-  lv_obj_align(extruder_temp.get_sensor(), LV_ALIGN_TOP_LEFT, 50, 0);
+  lv_obj_align(extruder_temp.get_sensor(), LV_ALIGN_TOP_LEFT, 20, 0);
 
   // lv_obj_set_size(extruder_temp.get_sensor(), 350, 60);
   // col 0
@@ -97,27 +105,27 @@ ExtruderPanel::ExtruderPanel(KWebSocketClient &websocket_client,
   // lv_obj_set_grid_cell(unload_btn.get_container(), LV_GRID_ALIGN_CENTER, 0, 1, LV_GRID_ALIGN_START, 2, 2);
   // lv_obj_set_grid_cell(cooldown_btn.get_container(), LV_GRID_ALIGN_END, 0, 1, LV_GRID_ALIGN_END, 2, 2);
 
-  lv_obj_set_grid_cell(leftside_btns_cont, LV_GRID_ALIGN_CENTER, 0, 1, LV_GRID_ALIGN_CENTER, 1, 3);
-  
+  lv_obj_set_grid_cell(leftside_btns_cont, LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 1, 3);
+
   // col 1
   // lv_obj_set_grid_cell(extruder_temp.get_sensor(), LV_GRID_ALIGN_CENTER, 0, 2, LV_GRID_ALIGN_CENTER, 0, 1);
-  lv_obj_set_grid_cell(speed_selector.get_container(), LV_GRID_ALIGN_CENTER, 1, 1, LV_GRID_ALIGN_CENTER, 1, 1);
-  lv_obj_set_grid_cell(length_selector.get_container(), LV_GRID_ALIGN_CENTER, 1, 1, LV_GRID_ALIGN_CENTER, 2, 1);
-  lv_obj_set_grid_cell(temp_selector.get_container(), LV_GRID_ALIGN_CENTER, 1, 1, LV_GRID_ALIGN_CENTER, 3, 1);
-  
+  lv_obj_set_grid_cell(speed_selector.get_container(), LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(length_selector.get_container(), LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH, 2, 1);
+  lv_obj_set_grid_cell(temp_selector.get_container(), LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH, 3, 1);
+
   // col 2
   // lv_obj_set_grid_cell(spoolman_btn.get_container(), LV_GRID_ALIGN_CENTER, 2, 1, LV_GRID_ALIGN_START, 0, 2);
   // lv_obj_set_grid_cell(retract_btn.get_container(), LV_GRID_ALIGN_CENTER, 2, 1, LV_GRID_ALIGN_END, 0, 2);
   // lv_obj_set_grid_cell(extrude_btn.get_container(), LV_GRID_ALIGN_CENTER, 2, 1, LV_GRID_ALIGN_START, 2, 2);
   // lv_obj_set_grid_cell(back_btn.get_container(), LV_GRID_ALIGN_END, 2, 1, LV_GRID_ALIGN_END, 2, 2);
 
-  lv_obj_set_grid_cell(rightside_btns_cont, LV_GRID_ALIGN_CENTER, 2, 1, LV_GRID_ALIGN_START, 0, 4);
+  lv_obj_set_grid_cell(rightside_btns_cont, LV_GRID_ALIGN_STRETCH, 2, 1, LV_GRID_ALIGN_STRETCH, 0, 4);
   // lv_obj_set_grid_cell(retract_btn.get_container(), LV_GRID_ALIGN_CENTER, 2, 1, LV_GRID_ALIGN_END, 0, 2);
   // lv_obj_set_grid_cell(extrude_btn.get_container(), LV_GRID_ALIGN_CENTER, 2, 1, LV_GRID_ALIGN_START, 2, 2);
   // lv_obj_set_grid_cell(back_btn.get_container(), LV_GRID_ALIGN_END, 2, 1, LV_GRID_ALIGN_END, 2, 2);
-  
 
-  ws.register_notify_update(this);    
+
+  ws.register_notify_update(this);
 }
 
 ExtruderPanel::~ExtruderPanel() {
@@ -142,9 +150,9 @@ void ExtruderPanel::consume(json& j) {
     int target = target_value.template get<int>();
     extruder_temp.update_target(target);
   }
-  
+
   auto temp_value = j["/params/0/extruder/temperature"_json_pointer];
-  if (!temp_value.is_null()) {   
+  if (!temp_value.is_null()) {
     int value = temp_value.template get<int>();
     extruder_temp.update_value(value);
   }
@@ -173,7 +181,7 @@ void ExtruderPanel::handle_callback(lv_event_t *e) {
 		  fmt::ptr(temp_selector.get_selector()),
 		  fmt::ptr(length_selector.get_selector()),
 		  fmt::ptr(speed_selector.get_selector()));
-    
+
   } else if (lv_event_get_code(e) == LV_EVENT_CLICKED) {
     lv_obj_t *btn = lv_event_get_current_target(e);
 

--- a/src/extruder_panel.cpp
+++ b/src/extruder_panel.cpp
@@ -15,21 +15,21 @@ LV_IMG_DECLARE(extruder);
 LV_IMG_DECLARE(cooldown_img);
 
 ExtruderPanel::ExtruderPanel(KWebSocketClient &websocket_client,
-			     std::mutex &lock,
-			     Numpad &numpad,
-			     SpoolmanPanel &sm)
+  std::mutex &lock,
+  Numpad &numpad,
+  SpoolmanPanel &sm)
   : NotifyConsumer(lock)
   , ws(websocket_client)
   , panel_cont(lv_obj_create(lv_scr_act()))
   , spoolman_panel(sm)
   , extruder_temp(ws, panel_cont, &extruder, 150,
-	  "Extruder", lv_palette_main(LV_PALETTE_RED), false, true, numpad, "extruder", NULL, NULL)
+    "Extruder", lv_palette_main(LV_PALETTE_RED), false, true, numpad, "extruder", NULL, NULL)
   , temp_selector(panel_cont, "Extruder Temperature (C)",
-		  {"180", "190", "200", "210", "220", "230", "240", ""}, 6, &ExtruderPanel::_handle_callback, this)
+    {"180", "190", "200", "210", "220", "230", "240", ""}, 6, &ExtruderPanel::_handle_callback, this)
   , length_selector(panel_cont, "Extrude Length (mm)",
-		    {"5", "10", "15", "20", "25", "30", "35", ""}, 1, &ExtruderPanel::_handle_callback, this)
+    {"5", "10", "15", "20", "25", "30", "35", ""}, 1, &ExtruderPanel::_handle_callback, this)
   , speed_selector(panel_cont, "Extrude Speed (mm/s)",
-		   {"1", "2", "5", "10", "25", "35", "50", ""}, 2, &ExtruderPanel::_handle_callback, this)
+    {"1", "2", "5", "10", "25", "35", "50", ""}, 2, &ExtruderPanel::_handle_callback, this)
   , rightside_btns_cont(lv_obj_create(panel_cont))
   , leftside_btns_cont(lv_obj_create(panel_cont))
   , load_btn(leftside_btns_cont, &load_filament_img, "Load", &ExtruderPanel::_handle_callback, this)
@@ -143,7 +143,7 @@ void ExtruderPanel::enable_spoolman() {
   spoolman_btn.enable();
 }
 
-void ExtruderPanel::consume(json& j) {
+void ExtruderPanel::consume(json &j) {
   std::lock_guard<std::mutex> lock(lv_lock);
   auto target_value = j["/params/0/extruder/target"_json_pointer];
   if (!target_value.is_null()) {
@@ -163,7 +163,7 @@ void ExtruderPanel::handle_callback(lv_event_t *e) {
   if (lv_event_get_code(e) == LV_EVENT_VALUE_CHANGED) {
     lv_obj_t *selector = lv_event_get_target(e);
     uint32_t idx = lv_btnmatrix_get_selected_btn(selector);
-    const char * v = lv_btnmatrix_get_btn_text(selector, idx);
+    const char *v = lv_btnmatrix_get_btn_text(selector, idx);
 
     if (selector == temp_selector.get_selector()) {
       temp_selector.set_selected_idx(idx);
@@ -178,9 +178,9 @@ void ExtruderPanel::handle_callback(lv_event_t *e) {
     }
 
     spdlog::trace("selector {} {} {}, {} {} {}", fmt::ptr(selector), idx, v,
-		  fmt::ptr(temp_selector.get_selector()),
-		  fmt::ptr(length_selector.get_selector()),
-		  fmt::ptr(speed_selector.get_selector()));
+      fmt::ptr(temp_selector.get_selector()),
+      fmt::ptr(length_selector.get_selector()),
+      fmt::ptr(speed_selector.get_selector()));
 
   } else if (lv_event_get_code(e) == LV_EVENT_CLICKED) {
     lv_obj_t *btn = lv_event_get_current_target(e);
@@ -190,29 +190,29 @@ void ExtruderPanel::handle_callback(lv_event_t *e) {
     }
 
     if (btn == extrude_btn.get_container()) {
-      const char * temp = lv_btnmatrix_get_btn_text(temp_selector.get_selector(),
-						   temp_selector.get_selected_idx());
-      const char * len = lv_btnmatrix_get_btn_text(length_selector.get_selector(),
-						   length_selector.get_selected_idx());
+      const char *temp = lv_btnmatrix_get_btn_text(temp_selector.get_selector(),
+        temp_selector.get_selected_idx());
+      const char *len = lv_btnmatrix_get_btn_text(length_selector.get_selector(),
+        length_selector.get_selected_idx());
       const char *speed = lv_btnmatrix_get_btn_text(speed_selector.get_selector(),
-						    speed_selector.get_selected_idx());
+        speed_selector.get_selected_idx());
       ws.gcode_script(fmt::format("M109 S{}\nM83\nG1 E{} F{}", temp, len, std::stoi(speed) * 60));
     }
 
     if (btn == retract_btn.get_container()) {
-      const char * temp = lv_btnmatrix_get_btn_text(temp_selector.get_selector(),
-						   temp_selector.get_selected_idx());
-      const char * len = lv_btnmatrix_get_btn_text(length_selector.get_selector(),
-						   length_selector.get_selected_idx());
+      const char *temp = lv_btnmatrix_get_btn_text(temp_selector.get_selector(),
+        temp_selector.get_selected_idx());
+      const char *len = lv_btnmatrix_get_btn_text(length_selector.get_selector(),
+        length_selector.get_selected_idx());
       const char *speed = lv_btnmatrix_get_btn_text(speed_selector.get_selector(),
-						    speed_selector.get_selected_idx());
+        speed_selector.get_selected_idx());
       ws.gcode_script(fmt::format("M109 S{}\nM83\nG1 E-{} F{}", temp, len, std::stoi(speed) * 60));
     }
 
     if (btn == unload_btn.get_container()) {
       if (unload_filament_macro == "_GUPPY_QUIT_MATERIAL") {
         const char *temp = lv_btnmatrix_get_btn_text(temp_selector.get_selector(),
-                                                     temp_selector.get_selected_idx());
+          temp_selector.get_selected_idx());
         ws.gcode_script(fmt::format("{} EXTRUDER_TEMP={}", unload_filament_macro, temp));
       } else {
         ws.gcode_script(unload_filament_macro);
@@ -222,9 +222,9 @@ void ExtruderPanel::handle_callback(lv_event_t *e) {
     if (btn == load_btn.get_container()) {
       if (load_filament_macro == "_GUPPY_LOAD_MATERIAL") {
         const char *temp = lv_btnmatrix_get_btn_text(temp_selector.get_selector(),
-                                                     temp_selector.get_selected_idx());
+          temp_selector.get_selected_idx());
         const char *len = lv_btnmatrix_get_btn_text(length_selector.get_selector(),
-                                                    length_selector.get_selected_idx());
+          length_selector.get_selected_idx());
         ws.gcode_script(fmt::format("{} EXTRUDER_TEMP={} EXTRUDE_LEN={}", load_filament_macro, temp, len));
       } else {
         ws.gcode_script(load_filament_macro);

--- a/src/fan_panel.cpp
+++ b/src/fan_panel.cpp
@@ -15,7 +15,7 @@ FanPanel::FanPanel(KWebSocketClient &websocket_client, std::mutex &lock)
   , back_btn(fanpanel_cont, &back, "Back", &FanPanel::_handle_callback, this)
 {
   lv_obj_set_style_pad_all(fanpanel_cont, 0, 0);
-  
+
   lv_obj_clear_flag(fanpanel_cont, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_size(fanpanel_cont, LV_PCT(100), LV_PCT(100));
 
@@ -81,7 +81,7 @@ void FanPanel::create_fans(json &f) {
   if (fans.size() > 3) {
     lv_obj_add_flag(fans_cont, LV_OBJ_FLAG_SCROLLABLE);
   } else {
-    lv_obj_clear_flag(fans_cont, LV_OBJ_FLAG_SCROLLABLE);    
+    lv_obj_clear_flag(fans_cont, LV_OBJ_FLAG_SCROLLABLE);
   }
 
   lv_obj_move_foreground(back_btn.get_container());
@@ -104,7 +104,7 @@ void FanPanel::foreground() {
       f.second->update_value(v);
     }
   }
-  
+
   lv_obj_move_foreground(back_btn.get_container());
   lv_obj_move_foreground(fanpanel_cont);
 }
@@ -170,7 +170,7 @@ void FanPanel::handle_fan_update_part_fan(lv_event_t *event) {
 
   } else if (lv_event_get_code(event) == LV_EVENT_CLICKED) {
     obj = lv_event_get_current_target(event);
-    
+
     for (auto &f : fans) {
       if (obj == f.second->get_off()) {
 	ws.gcode_script("M106 S0");

--- a/src/fan_panel.cpp
+++ b/src/fan_panel.cpp
@@ -73,7 +73,7 @@ void FanPanel::create_fans(json &f) {
       fan_cb = &FanPanel::_handle_fan_update_generic;
     }
     auto fptr = std::make_shared<SliderContainer>(fans_cont, display_name.c_str(), &cancel, "Off",
-						  &fan_on, "Max", fan_cb, this);
+      &fan_on, "Max", fan_cb, this);
     fans.insert({key, fptr});
     // lv_obj_set_grid_cell(fptr->get_container(), LV_GRID_ALIGN_CENTER, 0, 1, LV_GRID_ALIGN_CENTER, rowidx++, 1);
   }
@@ -113,8 +113,7 @@ void FanPanel::handle_callback(lv_event_t *event) {
   lv_obj_t *btn = lv_event_get_current_target(event);
   if (btn == back_btn.get_container()) {
     lv_obj_move_background(fanpanel_cont);
-  }
-  else {
+  } else {
     spdlog::debug("Unknown action button pressed");
   }
 }
@@ -128,27 +127,27 @@ void FanPanel::handle_fan_update(lv_event_t *event) {
     spdlog::trace("updating fan speed to {}", pct);
     for (auto &f : fans) {
       if (obj == f.second->get_slider()) {
-	std::string fan_name = KUtils::get_obj_name(f.first);
-      	spdlog::trace("update fan {}", fan_name);
-	ws.gcode_script(fmt::format(fmt::format("SET_PIN PIN={} VALUE={}", fan_name, pct)));
-	break;
+        std::string fan_name = KUtils::get_obj_name(f.first);
+        spdlog::trace("update fan {}", fan_name);
+        ws.gcode_script(fmt::format(fmt::format("SET_PIN PIN={} VALUE={}", fan_name, pct)));
+        break;
       }
     }
   } else if (lv_event_get_code(event) == LV_EVENT_CLICKED) {
     obj = lv_event_get_current_target(event);
     for (auto &f : fans) {
       if (obj == f.second->get_off()) {
-	std::string fan_name = KUtils::get_obj_name(f.first);
-      	spdlog::trace("turning off fan {}", fan_name);
-	ws.gcode_script(fmt::format("SET_PIN PIN={} VALUE=0", fan_name));
-	f.second->update_value(0);
-	break;
+        std::string fan_name = KUtils::get_obj_name(f.first);
+        spdlog::trace("turning off fan {}", fan_name);
+        ws.gcode_script(fmt::format("SET_PIN PIN={} VALUE=0", fan_name));
+        f.second->update_value(0);
+        break;
       } else if (obj == f.second->get_max()) {
-	std::string fan_name = KUtils::get_obj_name(f.first);
-	spdlog::trace("turning fan to max {}", fan_name);
-	ws.gcode_script(fmt::format("SET_PIN PIN={} VALUE=255", fan_name));
-	f.second->update_value(100);
-	break;
+        std::string fan_name = KUtils::get_obj_name(f.first);
+        spdlog::trace("turning fan to max {}", fan_name);
+        ws.gcode_script(fmt::format("SET_PIN PIN={} VALUE=255", fan_name));
+        f.second->update_value(100);
+        break;
       }
     }
   }
@@ -163,8 +162,8 @@ void FanPanel::handle_fan_update_part_fan(lv_event_t *event) {
     spdlog::trace("updating part fan speed to {}", pct);
     for (auto &f : fans) {
       if (obj == f.second->get_slider()) {
-	ws.gcode_script(fmt::format(fmt::format("M106 S{}", pct)));
-	break;
+        ws.gcode_script(fmt::format(fmt::format("M106 S{}", pct)));
+        break;
       }
     }
 
@@ -173,13 +172,13 @@ void FanPanel::handle_fan_update_part_fan(lv_event_t *event) {
 
     for (auto &f : fans) {
       if (obj == f.second->get_off()) {
-	ws.gcode_script("M106 S0");
-	f.second->update_value(0);
-	break;
+        ws.gcode_script("M106 S0");
+        f.second->update_value(0);
+        break;
       } else if (obj == f.second->get_max()) {
-	ws.gcode_script("M106 S255");
-	f.second->update_value(100);
-	break;
+        ws.gcode_script("M106 S255");
+        f.second->update_value(100);
+        break;
       }
     }
   }
@@ -194,10 +193,10 @@ void FanPanel::handle_fan_update_generic(lv_event_t *event) {
     spdlog::trace("updating fan speed to {}", pct);
     for (auto &f : fans) {
       if (obj == f.second->get_slider()) {
-	std::string fan_name = KUtils::get_obj_name(f.first);
-      	spdlog::trace("update fan {}", fan_name);
-	ws.gcode_script(fmt::format(fmt::format("SET_FAN_SPEED FAN={} SPEED={}", fan_name, pct)));
-	break;
+        std::string fan_name = KUtils::get_obj_name(f.first);
+        spdlog::trace("update fan {}", fan_name);
+        ws.gcode_script(fmt::format(fmt::format("SET_FAN_SPEED FAN={} SPEED={}", fan_name, pct)));
+        break;
       }
     }
   } else if (lv_event_get_code(event) == LV_EVENT_CLICKED) {
@@ -205,17 +204,17 @@ void FanPanel::handle_fan_update_generic(lv_event_t *event) {
 
     for (auto &f : fans) {
       if (obj == f.second->get_off()) {
-	std::string fan_name = KUtils::get_obj_name(f.first);
-      	spdlog::trace("turning off fan {}", fan_name);
-	ws.gcode_script(fmt::format("SET_FAN_SPEED FAN={} SPEED=0", fan_name));
-	f.second->update_value(0);
-	break;
+        std::string fan_name = KUtils::get_obj_name(f.first);
+        spdlog::trace("turning off fan {}", fan_name);
+        ws.gcode_script(fmt::format("SET_FAN_SPEED FAN={} SPEED=0", fan_name));
+        f.second->update_value(0);
+        break;
       } else if (obj == f.second->get_max()) {
-	std::string fan_name = KUtils::get_obj_name(f.first);
-	spdlog::trace("turning fan to max {}", fan_name);
-	ws.gcode_script(fmt::format("SET_FAN_SPEED FAN={} SPEED=1", fan_name));
-	f.second->update_value(100);
-	break;
+        std::string fan_name = KUtils::get_obj_name(f.first);
+        spdlog::trace("turning fan to max {}", fan_name);
+        ws.gcode_script(fmt::format("SET_FAN_SPEED FAN={} SPEED=1", fan_name));
+        f.second->update_value(100);
+        break;
       }
     }
   }

--- a/src/file_panel.cpp
+++ b/src/file_panel.cpp
@@ -66,7 +66,7 @@ void FilePanel::refresh_view(json &j, const std::string &gcode_path) {
   }
 
   v = j["/result/estimated_time"_json_pointer];
-  int eta =  v.is_null() ? -1 : v.template get<int>();
+  int eta = v.is_null() ? -1 : v.template get<int>();
   v = j["/result/filament_weight_total"_json_pointer];
   int fweight = v.is_null() ? -1 : v.template get<int>();
 
@@ -74,10 +74,10 @@ void FilePanel::refresh_view(json &j, const std::string &gcode_path) {
   lv_label_set_text(fname_label, filename.string().c_str());
 
   std::string detail = fmt::format("Filament Weight: {} g\nPrint Time: {}\nSize: {} MB\nModified: {}",
-                   fweight > 0 ? std::to_string(fweight) : "(unknown)",
-                   eta > 0 ? KUtils::eta_string(eta) : "(unknown)",
-                   KUtils::bytes_to_mb(j["result"]["size"].template get<size_t>()),
-                   time_stream.str());
+    fweight > 0 ? std::to_string(fweight) : "(unknown)",
+    eta > 0 ? KUtils::eta_string(eta) : "(unknown)",
+    KUtils::bytes_to_mb(j["result"]["size"].template get<size_t>()),
+    time_stream.str());
 
   auto width_scale = (double)lv_disp_get_physical_hor_res(NULL) / 800.0;
   auto thumb_result = KUtils::get_thumbnail(gcode_path, j, width_scale);
@@ -103,7 +103,7 @@ void FilePanel::refresh_view(json &j, const std::string &gcode_path) {
     lv_obj_align_to(thumbnail, thumbnail_container, LV_ALIGN_CENTER, 0, 0);
   } else {
     lv_img_set_src(thumbnail, NULL);
-    ((lv_img_t*)thumbnail)->src_type = LV_IMG_SRC_SYMBOL;
+    ((lv_img_t *)thumbnail)->src_type = LV_IMG_SRC_SYMBOL;
   }
 }
 
@@ -115,6 +115,6 @@ lv_obj_t *FilePanel::get_container() {
   return file_cont;
 }
 
-const char* FilePanel::get_thumbnail_path() {
-  return (const char*)lv_img_get_src(thumbnail);
+const char *FilePanel::get_thumbnail_path() {
+  return (const char *)lv_img_get_src(thumbnail);
 }

--- a/src/file_panel.h
+++ b/src/file_panel.h
@@ -15,12 +15,13 @@ class FilePanel {
   ~FilePanel();
 
   void foreground();
-  void refresh_view(json &j, const std::string &gcode_path);  
+  void refresh_view(json &j, const std::string &gcode_path);
   lv_obj_t *get_container();
   const char* get_thumbnail_path();
 
  private:
   lv_obj_t *file_cont;
+  lv_obj_t *thumbnail_container;
   lv_obj_t *thumbnail;
   lv_obj_t *fname_label;
   lv_obj_t *detail_label;

--- a/src/file_panel.h
+++ b/src/file_panel.h
@@ -10,16 +10,16 @@
 using json = nlohmann::json;
 
 class FilePanel {
- public:
+public:
   FilePanel(lv_obj_t *parent);
   ~FilePanel();
 
   void foreground();
   void refresh_view(json &j, const std::string &gcode_path);
   lv_obj_t *get_container();
-  const char* get_thumbnail_path();
+  const char *get_thumbnail_path();
 
- private:
+private:
   lv_obj_t *file_cont;
   lv_obj_t *thumbnail_container;
   lv_obj_t *thumbnail;

--- a/src/finetune_panel.cpp
+++ b/src/finetune_panel.cpp
@@ -36,12 +36,12 @@ FineTunePanel::FineTunePanel(KWebSocketClient &websocket_client, std::mutex &l)
   , flow_down_btn(panel_cont, &flow_down_img, "Flow-", &FineTunePanel::_handle_flow, this)
   , back_btn(panel_cont, &back, "Back", &FineTunePanel::_handle_callback, this)
   , zoffset_selector(panel_cont, "Z (mm) - PA (mm/s)",
-		     {"0.01", "0.05", "0.10", ""}, 0, 30, 15, &FineTunePanel::_handle_callback, this)
+    {"0.01", "0.05", "0.10", ""}, 0, 30, 15, &FineTunePanel::_handle_callback, this)
   , multipler_selector(panel_cont, "Multipler Step (%)",
-		       {"1", "5", "10", "25", ""}, 0, 40, 15, &FineTunePanel::_handle_callback, this)
+    {"1", "5", "10", "25", ""}, 0, 40, 15, &FineTunePanel::_handle_callback, this)
   , z_offset(values_cont, &home_z, 150, 100, 15, "0.0 mm")
   , pa(values_cont, &pa_plus_img, 150, 100, 15, "0.0 mm/s")
-  , speed_factor(values_cont, &speed_up_img, 150, 100, 15 ,"100%")
+  , speed_factor(values_cont, &speed_up_img, 150, 100, 15, "100%")
   , flow_factor(values_cont, &flow_up_img, 150, 100, 15, "100%")
 {
   lv_obj_move_background(panel_cont);
@@ -101,29 +101,29 @@ FineTunePanel::~FineTunePanel() {
 
 void FineTunePanel::foreground() {
   auto v = State::get_instance()->get_data(
-		"/printer_state/gcode_move/homing_origin/2"_json_pointer);
+    "/printer_state/gcode_move/homing_origin/2"_json_pointer);
   if (!v.is_null()) {
     z_offset.update_label(fmt::format("{:.5} mm", v.template get<double>()).c_str());
   }
 
   v = State::get_instance()->get_data(
-		"/printer_state/extruder/pressure_advance"_json_pointer);
+    "/printer_state/extruder/pressure_advance"_json_pointer);
   if (!v.is_null()) {
     pa.update_label(fmt::format("{:.5} mm/s", v.template get<double>()).c_str());
   }
 
   v = State::get_instance()->get_data(
-		"/printer_state/gcode_move/speed_factor"_json_pointer);
+    "/printer_state/gcode_move/speed_factor"_json_pointer);
   if (!v.is_null()) {
     speed_factor.update_label(fmt::format("{}%",
-	   static_cast<int>(v.template get<double>() * 100)).c_str());
+      static_cast<int>(v.template get<double>() * 100)).c_str());
   }
 
   v = State::get_instance()->get_data(
-		"/printer_state/gcode_move/extrude_factor"_json_pointer);
+    "/printer_state/gcode_move/extrude_factor"_json_pointer);
   if (!v.is_null()) {
     flow_factor.update_label(fmt::format("{}%",
-	   static_cast<int>(v.template get<double>() * 100)).c_str());
+      static_cast<int>(v.template get<double>() * 100)).c_str());
   }
 
   //Set the Z axis buttons
@@ -157,13 +157,13 @@ void FineTunePanel::consume(json &j) {
   v = j["/params/0/gcode_move/speed_factor"_json_pointer];
   if (!v.is_null()) {
     speed_factor.update_label(fmt::format("{}%",
-	   static_cast<int>(v.template get<double>() * 100)).c_str());
+      static_cast<int>(v.template get<double>() * 100)).c_str());
   }
 
   v = j["/params/0/gcode_move/extrude_factor"_json_pointer];
   if (!v.is_null()) {
     flow_factor.update_label(fmt::format("{}%",
-	   static_cast<int>(v.template get<double>() * 100)).c_str());
+      static_cast<int>(v.template get<double>() * 100)).c_str());
   }
 }
 
@@ -198,12 +198,12 @@ void FineTunePanel::handle_zoffset(lv_event_t *e) {
       spdlog::trace("clicked zoffset reset");
       ws.gcode_script("SET_GCODE_OFFSET Z=0 MOVE=1");
     } else {
-      const char * step = lv_btnmatrix_get_btn_text(zoffset_selector.get_selector(),
-						    zoffset_selector.get_selected_idx());
+      const char *step = lv_btnmatrix_get_btn_text(zoffset_selector.get_selector(),
+        zoffset_selector.get_selected_idx());
       spdlog::trace("clicked z {}", step);
       ws.gcode_script(fmt::format("SET_GCODE_OFFSET Z_ADJUST={}{} MOVE=1",
-				  btn == zup_btn.get_container() ? "+" : "-",
-				  step));
+        btn == zup_btn.get_container() ? "+" : "-",
+        step));
     }
   }
 }
@@ -215,22 +215,22 @@ void FineTunePanel::handle_pa(lv_event_t *e) {
     if (btn == pareset_btn.get_container()) {
       spdlog::trace("clicked pa reset");
       auto v = State::get_instance()->get_data(
-		     "/printer_state/configfile/settings/extruder/pressure_advance"_json_pointer);
+        "/printer_state/configfile/settings/extruder/pressure_advance"_json_pointer);
       if (!v.is_null()) {
-	ws.gcode_script(fmt::format("SET_PRESSURE_ADVANCE ADVANCE={}", v.template get<double>()));
+        ws.gcode_script(fmt::format("SET_PRESSURE_ADVANCE ADVANCE={}", v.template get<double>()));
       }
     } else {
 
       auto cur_pa = State::get_instance()
-	->get_data("/printer_state/extruder/pressure_advance"_json_pointer);
+        ->get_data("/printer_state/extruder/pressure_advance"_json_pointer);
       if (!cur_pa.is_null()) {
-	const char * step = lv_btnmatrix_get_btn_text(zoffset_selector.get_selector(),
-						      zoffset_selector.get_selected_idx());
+        const char *step = lv_btnmatrix_get_btn_text(zoffset_selector.get_selector(),
+          zoffset_selector.get_selected_idx());
 
-	double direction = btn == paup_btn.get_container() ? std::stod(step) : -std::stod(step);
-	double new_pa = cur_pa.template get<double>() + direction;
-	new_pa = new_pa < 0 ? 0 : new_pa;
-	ws.gcode_script(fmt::format("SET_PRESSURE_ADVANCE ADVANCE={}", new_pa));
+        double direction = btn == paup_btn.get_container() ? std::stod(step) : -std::stod(step);
+        double new_pa = cur_pa.template get<double>() + direction;
+        new_pa = new_pa < 0 ? 0 : new_pa;
+        ws.gcode_script(fmt::format("SET_PRESSURE_ADVANCE ADVANCE={}", new_pa));
       }
     }
   }
@@ -244,16 +244,16 @@ void FineTunePanel::handle_speed(lv_event_t *e) {
       ws.gcode_script("M220 S100");
     } else {
       auto spd_factor = State::get_instance()
-	->get_data("/printer_state/gcode_move/speed_factor"_json_pointer);
+        ->get_data("/printer_state/gcode_move/speed_factor"_json_pointer);
       if (!spd_factor.is_null()) {
-	const char * step = lv_btnmatrix_get_btn_text(multipler_selector.get_selector(),
-						      multipler_selector.get_selected_idx());
+        const char *step = lv_btnmatrix_get_btn_text(multipler_selector.get_selector(),
+          multipler_selector.get_selected_idx());
 
-	int32_t direction = btn == speed_up_btn.get_container() ? std::stoi(step) : -std::stoi(step);
-	int32_t new_speed = static_cast<int32_t>(spd_factor.template get<double>() * 100 + direction);
-	new_speed = std::max(new_speed, 1);
-	spdlog::trace("speed step {}, {}", direction, new_speed);
-	ws.gcode_script(fmt::format("M220 S{}", new_speed));
+        int32_t direction = btn == speed_up_btn.get_container() ? std::stoi(step) : -std::stoi(step);
+        int32_t new_speed = static_cast<int32_t>(spd_factor.template get<double>() * 100 + direction);
+        new_speed = std::max(new_speed, 1);
+        spdlog::trace("speed step {}, {}", direction, new_speed);
+        ws.gcode_script(fmt::format("M220 S{}", new_speed));
       }
     }
   }
@@ -267,17 +267,17 @@ void FineTunePanel::handle_flow(lv_event_t *e) {
       ws.gcode_script("M221 S100");
     } else {
       auto extrude_factor = State::get_instance()
-	->get_data("/printer_state/gcode_move/extrude_factor"_json_pointer);
+        ->get_data("/printer_state/gcode_move/extrude_factor"_json_pointer);
       if (!extrude_factor.is_null()) {
-	const char * step = lv_btnmatrix_get_btn_text(multipler_selector.get_selector(),
-						      multipler_selector.get_selected_idx());
+        const char *step = lv_btnmatrix_get_btn_text(multipler_selector.get_selector(),
+          multipler_selector.get_selected_idx());
 
-	int32_t direction = btn == flow_up_btn.get_container() ? std::stoi(step) : -std::stoi(step);
+        int32_t direction = btn == flow_up_btn.get_container() ? std::stoi(step) : -std::stoi(step);
 
-	int32_t new_flow = static_cast<int32_t>(extrude_factor.template get<double>() * 100 + direction);
-	new_flow = std::max(new_flow, 1);
-	spdlog::trace("flow step {}, {}", direction, new_flow);
-	ws.gcode_script(fmt::format("M221 S{}", new_flow));
+        int32_t new_flow = static_cast<int32_t>(extrude_factor.template get<double>() * 100 + direction);
+        new_flow = std::max(new_flow, 1);
+        spdlog::trace("flow step {}, {}", direction, new_flow);
+        ws.gcode_script(fmt::format("M221 S{}", new_flow));
       }
     }
   }

--- a/src/finetune_panel.cpp
+++ b/src/finetune_panel.cpp
@@ -28,7 +28,7 @@ FineTunePanel::FineTunePanel(KWebSocketClient &websocket_client, std::mutex &l)
   , pareset_btn(panel_cont, &refresh_img, "Reset PA", &FineTunePanel::_handle_pa, this)
   , paup_btn(panel_cont, &pa_plus_img, "PA+", &FineTunePanel::_handle_pa, this)
   , padown_btn(panel_cont, &pa_minus_img, "PA-", &FineTunePanel::_handle_pa, this)
-  , speed_reset_btn(panel_cont, &refresh_img, "Speed Reset", &FineTunePanel::_handle_speed, this)    
+  , speed_reset_btn(panel_cont, &refresh_img, "Speed Reset", &FineTunePanel::_handle_speed, this)
   , speed_up_btn(panel_cont, &speed_up_img, "Speed+", &FineTunePanel::_handle_speed, this)
   , speed_down_btn(panel_cont, &speed_down_img, "Speed-", &FineTunePanel::_handle_speed, this)
   , flow_reset_btn(panel_cont, &refresh_img, "Flow Reset", &FineTunePanel::_handle_flow, this)
@@ -45,7 +45,7 @@ FineTunePanel::FineTunePanel(KWebSocketClient &websocket_client, std::mutex &l)
   , flow_factor(values_cont, &flow_up_img, 150, 100, 15, "100%")
 {
   lv_obj_move_background(panel_cont);
-  
+
   lv_obj_set_size(panel_cont, LV_PCT(100), LV_PCT(100));
   lv_obj_clear_flag(panel_cont, LV_OBJ_FLAG_SCROLLABLE);
 
@@ -63,30 +63,30 @@ FineTunePanel::FineTunePanel(KWebSocketClient &websocket_client, std::mutex &l)
   lv_obj_set_grid_dsc_array(panel_cont, grid_main_col_dsc, grid_main_row_dsc);
 
   // col 1
-  lv_obj_set_grid_cell(zreset_btn.get_container(), LV_GRID_ALIGN_CENTER, 0, 1, LV_GRID_ALIGN_CENTER, 0, 1);
-  lv_obj_set_grid_cell(zup_btn.get_container(), LV_GRID_ALIGN_CENTER, 0, 1, LV_GRID_ALIGN_CENTER, 1, 1);
-  lv_obj_set_grid_cell(zdown_btn.get_container(), LV_GRID_ALIGN_CENTER, 0, 1, LV_GRID_ALIGN_CENTER, 2, 1);
-  lv_obj_set_grid_cell(zoffset_selector.get_container(), LV_GRID_ALIGN_CENTER, 0, 2, LV_GRID_ALIGN_CENTER, 3, 1);
+  lv_obj_set_grid_cell(zreset_btn.get_container(), LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
+  lv_obj_set_grid_cell(zup_btn.get_container(), LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(zdown_btn.get_container(), LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 2, 1);
+  lv_obj_set_grid_cell(zoffset_selector.get_container(), LV_GRID_ALIGN_STRETCH, 0, 2, LV_GRID_ALIGN_STRETCH, 3, 1);
 
   // col 2
-  lv_obj_set_grid_cell(pareset_btn.get_container(), LV_GRID_ALIGN_CENTER, 1, 1, LV_GRID_ALIGN_CENTER, 0, 1);
-  lv_obj_set_grid_cell(paup_btn.get_container(), LV_GRID_ALIGN_CENTER, 1, 1, LV_GRID_ALIGN_CENTER, 1, 1);
-  lv_obj_set_grid_cell(padown_btn.get_container(), LV_GRID_ALIGN_CENTER, 1, 1, LV_GRID_ALIGN_CENTER, 2, 1);
-  
+  lv_obj_set_grid_cell(pareset_btn.get_container(), LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
+  lv_obj_set_grid_cell(paup_btn.get_container(), LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(padown_btn.get_container(), LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH, 2, 1);
+
   // col 3
-  lv_obj_set_grid_cell(speed_reset_btn.get_container(), LV_GRID_ALIGN_CENTER, 2, 1, LV_GRID_ALIGN_CENTER, 0, 1);
-  lv_obj_set_grid_cell(speed_up_btn.get_container(), LV_GRID_ALIGN_CENTER, 2, 1, LV_GRID_ALIGN_CENTER, 1, 1);
-  lv_obj_set_grid_cell(speed_down_btn.get_container(), LV_GRID_ALIGN_CENTER, 2, 1, LV_GRID_ALIGN_CENTER, 2, 1);
-  lv_obj_set_grid_cell(multipler_selector.get_container(), LV_GRID_ALIGN_CENTER, 2, 2, LV_GRID_ALIGN_CENTER, 3, 1);  
+  lv_obj_set_grid_cell(speed_reset_btn.get_container(), LV_GRID_ALIGN_STRETCH, 2, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
+  lv_obj_set_grid_cell(speed_up_btn.get_container(), LV_GRID_ALIGN_STRETCH, 2, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(speed_down_btn.get_container(), LV_GRID_ALIGN_STRETCH, 2, 1, LV_GRID_ALIGN_STRETCH, 2, 1);
+  lv_obj_set_grid_cell(multipler_selector.get_container(), LV_GRID_ALIGN_STRETCH, 2, 2, LV_GRID_ALIGN_STRETCH, 3, 1);
 
   // col 4
-  lv_obj_set_grid_cell(flow_reset_btn.get_container(), LV_GRID_ALIGN_CENTER, 3, 1, LV_GRID_ALIGN_CENTER, 0, 1);
-  lv_obj_set_grid_cell(flow_up_btn.get_container(), LV_GRID_ALIGN_CENTER, 3, 1, LV_GRID_ALIGN_CENTER, 1, 1);
-  lv_obj_set_grid_cell(flow_down_btn.get_container(), LV_GRID_ALIGN_CENTER, 3, 1, LV_GRID_ALIGN_CENTER, 2, 1);
+  lv_obj_set_grid_cell(flow_reset_btn.get_container(), LV_GRID_ALIGN_STRETCH, 3, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
+  lv_obj_set_grid_cell(flow_up_btn.get_container(), LV_GRID_ALIGN_STRETCH, 3, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(flow_down_btn.get_container(), LV_GRID_ALIGN_STRETCH, 3, 1, LV_GRID_ALIGN_STRETCH, 2, 1);
 
   // col 5
-  lv_obj_set_grid_cell(values_cont, LV_GRID_ALIGN_CENTER, 4, 1, LV_GRID_ALIGN_CENTER, 0, 3);  
-  lv_obj_set_grid_cell(back_btn.get_container(), LV_GRID_ALIGN_CENTER, 4, 1, LV_GRID_ALIGN_CENTER, 3, 1);
+  lv_obj_set_grid_cell(values_cont, LV_GRID_ALIGN_STRETCH, 4, 1, LV_GRID_ALIGN_STRETCH, 0, 3);
+  lv_obj_set_grid_cell(back_btn.get_container(), LV_GRID_ALIGN_STRETCH, 4, 1, LV_GRID_ALIGN_STRETCH, 3, 1);
 
   ws.register_notify_update(this);
 }
@@ -138,7 +138,7 @@ void FineTunePanel::foreground() {
     zup_btn.set_image(&z_closer);
     zdown_btn.set_image(&z_farther);
   }
-  
+
   lv_obj_move_foreground(panel_cont);
 }
 
@@ -181,7 +181,7 @@ void FineTunePanel::handle_callback(lv_event_t *e) {
       multipler_selector.set_selected_idx(idx);
     }
   }
-  
+
   if (lv_event_get_code(e) == LV_EVENT_CLICKED) {
     lv_obj_t *btn = lv_event_get_current_target(e);
     if (btn == back_btn.get_container()) {
@@ -226,7 +226,7 @@ void FineTunePanel::handle_pa(lv_event_t *e) {
       if (!cur_pa.is_null()) {
 	const char * step = lv_btnmatrix_get_btn_text(zoffset_selector.get_selector(),
 						      zoffset_selector.get_selected_idx());
-	
+
 	double direction = btn == paup_btn.get_container() ? std::stod(step) : -std::stod(step);
 	double new_pa = cur_pa.template get<double>() + direction;
 	new_pa = new_pa < 0 ? 0 : new_pa;
@@ -273,7 +273,7 @@ void FineTunePanel::handle_flow(lv_event_t *e) {
 						      multipler_selector.get_selected_idx());
 
 	int32_t direction = btn == flow_up_btn.get_container() ? std::stoi(step) : -std::stoi(step);
-	
+
 	int32_t new_flow = static_cast<int32_t>(extrude_factor.template get<double>() * 100 + direction);
 	new_flow = std::max(new_flow, 1);
 	spdlog::trace("flow step {}, {}", direction, new_flow);

--- a/src/guppyscreen.cpp
+++ b/src/guppyscreen.cpp
@@ -193,7 +193,6 @@ void GuppyScreen::loop() {
 #if !defined(SIMULATOR) && !defined(OS_ANDROID)
   std::atomic_bool is_sleeping(false);
   Config *conf = Config::get_instance();
-  int32_t display_sleep = conf->get<int32_t>("/display_sleep_sec") * 1000;
 #endif
 
   while (1) {
@@ -201,7 +200,8 @@ void GuppyScreen::loop() {
     lv_timer_handler();
     lv_lock.unlock();
 
-#if !defined(SIMULATOR) && !defined(OS_ANDROID)
+  #if !defined(SIMULATOR) && !defined(OS_ANDROID)
+    int32_t display_sleep = conf->get<int32_t>("/display_sleep_sec") * 1000;
     if (display_sleep != -1) {
       if (lv_disp_get_inactive_time(NULL) > display_sleep) {
         if (!is_sleeping.load()) {
@@ -222,7 +222,7 @@ void GuppyScreen::loop() {
     }
 #endif  // SIMULATOR/OS_ANDROID
 
-    usleep(5000);
+    usleep(10000);
   }
 }
 

--- a/src/homing_panel.cpp
+++ b/src/homing_panel.cpp
@@ -29,24 +29,24 @@ HomingPanel::HomingPanel(KWebSocketClient &websocket_client, std::mutex &lock)
   , z_up_btn(homing_cont, &z_closer, "Z+", &HomingPanel::_handle_callback, this)
   , z_down_btn(homing_cont, &z_farther, "Z-", &HomingPanel::_handle_callback, this)
   , emergency_btn(homing_cont, &emergency, "Stop", &HomingPanel::_handle_callback, this,
-		  "Do you want to emergency stop?",
-		  [&websocket_client]() {
-		    spdlog::debug("emergency stop pressed");
-		    websocket_client.send_jsonrpc("printer.emergency_stop");
-		  })
+    "Do you want to emergency stop?",
+    [&websocket_client]() {
+      spdlog::debug("emergency stop pressed");
+      websocket_client.send_jsonrpc("printer.emergency_stop");
+    })
   , motoroff_btn(homing_cont, &motor_off_img, "Motor Off", &HomingPanel::_handle_callback, this)
   , back_btn(homing_cont, &back, "Back", &HomingPanel::_handle_callback, this)
   , speed_selector(homing_cont, "Move Speed (mm/s)",
-    { "10", "50", "100", "200", "400", "600", "" }, 2, 50, 10, & HomingPanel::_handle_speed_selector_cb, this)
+    {"10", "50", "100", "200", "400", "600", ""}, 2, 50, 10, &HomingPanel::_handle_speed_selector_cb, this)
   , distance_selector(homing_cont, "Move Distance (mm)",
-    { "0.1", "1", "5", "10", "50", "100", "" }, 3, 50, 10, & HomingPanel::_handle_selector_cb, this)
+    {"0.1", "1", "5", "10", "50", "100", ""}, 3, 50, 10, &HomingPanel::_handle_selector_cb, this)
 {
   lv_obj_clear_flag(homing_cont, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_height(homing_cont, lv_pct(100));
   lv_obj_set_width(homing_cont, lv_pct(100));
 
-  static lv_coord_t grid_main_row_dsc[] = { LV_GRID_FR(4), LV_GRID_FR(4), LV_GRID_FR(2), LV_GRID_FR(2), LV_GRID_TEMPLATE_LAST };
-  static lv_coord_t grid_main_col_dsc[] = { LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST };
+  static lv_coord_t grid_main_row_dsc[] = {LV_GRID_FR(4), LV_GRID_FR(4), LV_GRID_FR(2), LV_GRID_FR(2), LV_GRID_TEMPLATE_LAST};
+  static lv_coord_t grid_main_col_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
 
   lv_obj_set_grid_dsc_array(homing_cont, grid_main_col_dsc, grid_main_row_dsc);
 
@@ -54,14 +54,14 @@ HomingPanel::HomingPanel(KWebSocketClient &websocket_client, std::mutex &lock)
   lv_obj_set_grid_cell(home_all_btn.get_container(), LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
   lv_obj_set_grid_cell(y_up_btn.get_container(), LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
   lv_obj_set_grid_cell(home_xy_btn.get_container(), LV_GRID_ALIGN_STRETCH, 2, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
-  lv_obj_set_grid_cell(z_up_btn.get_container(), LV_GRID_ALIGN_STRETCH, 3, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
+  lv_obj_set_grid_cell(z_down_btn.get_container(), LV_GRID_ALIGN_STRETCH, 3, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
   lv_obj_set_grid_cell(emergency_btn.get_container(), LV_GRID_ALIGN_STRETCH, 4, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
 
   // row 2
   lv_obj_set_grid_cell(x_down_btn.get_container(), LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
   lv_obj_set_grid_cell(y_down_btn.get_container(), LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
   lv_obj_set_grid_cell(x_up_btn.get_container(), LV_GRID_ALIGN_STRETCH, 2, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
-  lv_obj_set_grid_cell(z_down_btn.get_container(), LV_GRID_ALIGN_STRETCH, 3, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(z_up_btn.get_container(), LV_GRID_ALIGN_STRETCH, 3, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
   lv_obj_set_grid_cell(motoroff_btn.get_container(), LV_GRID_ALIGN_STRETCH, 4, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
 
   lv_obj_set_grid_cell(speed_selector.get_container(), LV_GRID_ALIGN_STRETCH, 0, 4, LV_GRID_ALIGN_STRETCH, 2, 1);
@@ -73,8 +73,7 @@ HomingPanel::HomingPanel(KWebSocketClient &websocket_client, std::mutex &lock)
   ws.register_notify_update(this);
 }
 
-HomingPanel::~HomingPanel() {
-}
+HomingPanel::~HomingPanel() { }
 
 void HomingPanel::consume(json &j) {
   auto v = j["/params/0/toolhead/homed_axes"_json_pointer];
@@ -145,105 +144,117 @@ void HomingPanel::foreground() {
     }
   }
 
-  //Set the Z axis buttons
-
-  v = Config::get_instance()->get_json("/invert_z_icon");
-  bool inverted = !v.is_null() && v.template get<bool>();
-  if (inverted) {
-    // UP arrow
-    z_up_btn.set_image(&z_farther);
-    z_down_btn.set_image(&z_closer);
-  } else {
-    // DOWN arrow
-    z_up_btn.set_image(&z_closer);
-    z_down_btn.set_image(&z_farther);
-  }
-
   lv_obj_move_foreground(homing_cont);
 }
 
 void HomingPanel::handle_callback(lv_event_t *event) {
   lv_obj_t *btn = lv_event_get_current_target(event);
-  const char * distance = lv_btnmatrix_get_btn_text(distance_selector.get_selector(),
-						    distance_selector.get_selected_idx());
-  const char* speed = lv_btnmatrix_get_btn_text(speed_selector.get_selector(),
-    speed_selector.get_selected_idx());
-  int speed_mm_min = static_cast<int>(std::round(std::stod(speed) * 60));
   std::string move_op;
 
   if (btn == home_all_btn.get_container()) {
     spdlog::debug("home all pressed");
     ws.gcode_script("G28 X Y Z");
-
-  }
-  else if (btn == home_xy_btn.get_container()) {
+  } else if (btn == home_xy_btn.get_container()) {
     spdlog::debug("home xy pressed");
     ws.gcode_script("G28 X Y");
-
-  }
-  else if (btn == y_up_btn.get_container()) {
-    spdlog::debug("y up pressed");
-    move_op = fmt::format("G0 Y+{} F{}", distance, speed_mm_min);
-
-  }
-  else if (btn == y_down_btn.get_container()) {
-    spdlog::debug("y down pressed");
-    move_op = fmt::format("G0 Y-{} F{}", distance, speed_mm_min);
-
-  }
-  else if (btn == x_up_btn.get_container()) {
-    spdlog::debug("x up pressed");
-    move_op = fmt::format("G0 X+{} F{}", distance, speed_mm_min);
-
-  }
-  else if (btn == x_down_btn.get_container()) {
-    spdlog::debug("x down pressed");
-    move_op = fmt::format("G0 X-{} F{}", distance, speed_mm_min);
-
-  }
-  else if (btn == z_up_btn.get_container()) {
-    spdlog::debug("z up pressed");
-    move_op = fmt::format("G0 Z+{} F{}", distance, speed_mm_min);
-
-  }
-  else if (btn == z_down_btn.get_container()) {
-    spdlog::debug("z down pressed");
-    move_op = fmt::format("G0 Z-{} F{}", distance, speed_mm_min);
-
-  }
-  else if (btn == emergency_btn.get_container()) {
+  } else if (btn == emergency_btn.get_container()) {
     spdlog::debug("emergency stop pressed");
     ws.send_jsonrpc("printer.emergency_stop");
-
-  }
-  else if (btn == motoroff_btn.get_container()) {
+  } else if (btn == motoroff_btn.get_container()) {
     spdlog::debug("motor off pressed");
     ws.gcode_script("M84");
-
   } else if (btn == back_btn.get_container()) {
     lv_obj_move_background(homing_cont);
   }
-  else {
-    spdlog::debug("Unknown action button pressed");
+
+  // For movement commands, get current state and UI values
+  auto state = State::get_instance()->get_data("/printer_state/toolhead"_json_pointer);
+  if (state.is_null() || !state.contains("position") || !state.contains("axis_minimum") || !state.contains("axis_maximum")) {
+    spdlog::error("Failed to get valid printer toolhead state for movement.");
+    return;
   }
 
-  if (move_op.size() > 0) {
+  try {
+    const char *distance_str = lv_btnmatrix_get_btn_text(distance_selector.get_selector(),
+      distance_selector.get_selected_idx());
+    const char *speed_str = lv_btnmatrix_get_btn_text(speed_selector.get_selector(),
+      speed_selector.get_selected_idx());
+
+    double move_dist = std::stod(distance_str);
+    int speed_mm_min = static_cast<int>(std::round(std::stod(speed_str) * 60));
+
+    auto current_pos = state["position"].get<std::vector<double>>();
+    auto min_pos = state["axis_minimum"].get<std::vector<double>>();
+    auto max_pos = state["axis_maximum"].get<std::vector<double>>();
+
+    for (auto &pos : min_pos) {
+      pos = std::max(pos, 0.0);
+    }
+    for (auto &pos : max_pos) {
+      pos = std::round(pos / 10) * 10;
+    }
+
+    double current_x = current_pos[0];
+    double current_y = current_pos[1];
+    double current_z = current_pos[2];
+
+    bool invert_z = false;
+    auto invert_z_json = Config::get_instance()->get_json("/invert_z_direction");
+    if (invert_z_json.is_boolean()) {
+      invert_z = invert_z_json.get<bool>();
+    }
+
+    if (btn == x_up_btn.get_container()) {
+      spdlog::debug("x up pressed");
+      double target_x = std::clamp(current_x + move_dist, min_pos[0], max_pos[0]);
+      move_op = fmt::format("G0 X{:.4f} F{}", target_x, speed_mm_min);
+    } else if (btn == x_down_btn.get_container()) {
+      spdlog::debug("x down pressed");
+      double target_x = std::clamp(current_x - move_dist, min_pos[0], max_pos[0]);
+      move_op = fmt::format("G0 X{:.4f} F{}", target_x, speed_mm_min);
+    } else if (btn == y_up_btn.get_container()) {
+      spdlog::debug("y up pressed");
+      double target_y = std::clamp(current_y + move_dist, min_pos[1], max_pos[1]);
+      move_op = fmt::format("G0 Y{:.4f} F{}", target_y, speed_mm_min);
+    } else if (btn == y_down_btn.get_container()) {
+      spdlog::debug("y down pressed");
+      double target_y = std::clamp(current_y - move_dist, min_pos[1], max_pos[1]);
+      move_op = fmt::format("G0 Y{:.4f} F{}", target_y, speed_mm_min);
+    } else if (btn == z_up_btn.get_container()) {
+      spdlog::debug("z up pressed{}", invert_z ? " (inverted)" : "");
+      double z_offset = invert_z ? -move_dist : +move_dist;
+      double target_z = std::clamp(current_z + z_offset, min_pos[2], max_pos[2] / 10 * 10 );
+      move_op = fmt::format("G0 Z{:.4f} F{}", target_z, speed_mm_min);
+    } else if (btn == z_down_btn.get_container()) {
+      spdlog::debug("z down pressed{}", invert_z ? " (inverted)" : "");
+      double z_offset = invert_z ? +move_dist : -move_dist;
+      double target_z = std::clamp(current_z + z_offset, min_pos[2], max_pos[2] / 10 * 10);
+      move_op = fmt::format("G0 Z{:.4f} F{}", target_z, speed_mm_min);
+    } else {
+      spdlog::debug("Unknown action button pressed");
+    }
+  } catch (const std::exception &e) {
+    spdlog::error("Error processing movement command: {}", e.what());
+    return;
+  }
+
+  if (!move_op.empty()) {
     std::string gcode = fmt::format(
-      "SAVE_GCODE_STATE NAME=_guppy_movement\nG91\n{}\nG90\nRESTORE_GCODE_STATE NAME=_guppy_movement",
+      "SAVE_GCODE_STATE NAME=_guppy_movement\nG90\n{}\nRESTORE_GCODE_STATE NAME=_guppy_movement",
       move_op);
     ws.gcode_script(gcode);
   }
 }
 
 void HomingPanel::handle_selector_cb(lv_event_t *event) {
-  lv_obj_t * obj = lv_event_get_target(event);
+  lv_obj_t *obj = lv_event_get_target(event);
   uint32_t idx = lv_btnmatrix_get_selected_btn(obj);
   distance_selector.set_selected_idx(idx);
   spdlog::debug("selector move distance index {}", idx);
 }
 
 void HomingPanel::handle_speed_selector_cb(lv_event_t *event) {
-  lv_obj_t* obj = lv_event_get_target(event);
+  lv_obj_t *obj = lv_event_get_target(event);
   uint32_t idx = lv_btnmatrix_get_selected_btn(obj);
   speed_selector.set_selected_idx(idx);
   spdlog::debug("selector move speed index {}", idx);

--- a/src/homing_panel.cpp
+++ b/src/homing_panel.cpp
@@ -23,7 +23,7 @@ HomingPanel::HomingPanel(KWebSocketClient &websocket_client, std::mutex &lock)
   , home_all_btn(homing_cont, &home, "Home All", &HomingPanel::_handle_callback, this)
   , home_xy_btn(homing_cont, &home, "Home XY", &HomingPanel::_handle_callback, this)
   , y_up_btn(homing_cont, &arrow_up, "Y+", &HomingPanel::_handle_callback, this)
-  , y_down_btn(homing_cont, &arrow_down, "Y-", &HomingPanel::_handle_callback, this)    
+  , y_down_btn(homing_cont, &arrow_down, "Y-", &HomingPanel::_handle_callback, this)
   , x_up_btn(homing_cont, &arrow_right, "X+", &HomingPanel::_handle_callback, this)
   , x_down_btn(homing_cont, &arrow_left, "X-", &HomingPanel::_handle_callback, this)
   , z_up_btn(homing_cont, &z_closer, "Z+", &HomingPanel::_handle_callback, this)
@@ -36,36 +36,38 @@ HomingPanel::HomingPanel(KWebSocketClient &websocket_client, std::mutex &lock)
 		  })
   , motoroff_btn(homing_cont, &motor_off_img, "Motor Off", &HomingPanel::_handle_callback, this)
   , back_btn(homing_cont, &back, "Back", &HomingPanel::_handle_callback, this)
+  , speed_selector(homing_cont, "Move Speed (mm/s)",
+    { "10", "50", "100", "200", "400", "600", "" }, 2, 50, 10, & HomingPanel::_handle_speed_selector_cb, this)
   , distance_selector(homing_cont, "Move Distance (mm)",
-		     {".1", ".5", "1", "5", "10", "25", "50", ""}, 2, 70, 15, &HomingPanel::_handle_selector_cb, this)
+    { "0.1", "1", "5", "10", "50", "100", "" }, 3, 50, 10, & HomingPanel::_handle_selector_cb, this)
 {
   lv_obj_clear_flag(homing_cont, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_height(homing_cont, lv_pct(100));
   lv_obj_set_width(homing_cont, lv_pct(100));
 
-  static lv_coord_t grid_main_row_dsc[] = {LV_GRID_FR(4), LV_GRID_FR(4), LV_GRID_FR(2), LV_GRID_TEMPLATE_LAST};
-  static lv_coord_t grid_main_col_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1),
-    LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
+  static lv_coord_t grid_main_row_dsc[] = { LV_GRID_FR(4), LV_GRID_FR(4), LV_GRID_FR(2), LV_GRID_FR(2), LV_GRID_TEMPLATE_LAST };
+  static lv_coord_t grid_main_col_dsc[] = { LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST };
 
   lv_obj_set_grid_dsc_array(homing_cont, grid_main_col_dsc, grid_main_row_dsc);
 
   // row 1
-  lv_obj_set_grid_cell(home_all_btn.get_container(), LV_GRID_ALIGN_CENTER, 0, 1, LV_GRID_ALIGN_CENTER, 0, 1);
-  lv_obj_set_grid_cell(y_up_btn.get_container(), LV_GRID_ALIGN_CENTER, 1, 1, LV_GRID_ALIGN_CENTER, 0, 1);
-  lv_obj_set_grid_cell(home_xy_btn.get_container(), LV_GRID_ALIGN_CENTER, 2, 1, LV_GRID_ALIGN_CENTER, 0, 1);
-  lv_obj_set_grid_cell(z_up_btn.get_container(), LV_GRID_ALIGN_CENTER, 3, 1, LV_GRID_ALIGN_CENTER, 0, 1); 
-  lv_obj_set_grid_cell(emergency_btn.get_container(), LV_GRID_ALIGN_CENTER, 4, 1, LV_GRID_ALIGN_CENTER, 0, 1);
+  lv_obj_set_grid_cell(home_all_btn.get_container(), LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
+  lv_obj_set_grid_cell(y_up_btn.get_container(), LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
+  lv_obj_set_grid_cell(home_xy_btn.get_container(), LV_GRID_ALIGN_STRETCH, 2, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
+  lv_obj_set_grid_cell(z_up_btn.get_container(), LV_GRID_ALIGN_STRETCH, 3, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
+  lv_obj_set_grid_cell(emergency_btn.get_container(), LV_GRID_ALIGN_STRETCH, 4, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
 
   // row 2
-  lv_obj_set_grid_cell(x_down_btn.get_container(), LV_GRID_ALIGN_CENTER, 0, 1, LV_GRID_ALIGN_CENTER, 1, 1);
-  lv_obj_set_grid_cell(y_down_btn.get_container(), LV_GRID_ALIGN_CENTER, 1, 1, LV_GRID_ALIGN_CENTER, 1, 1);
-  lv_obj_set_grid_cell(x_up_btn.get_container(), LV_GRID_ALIGN_CENTER, 2, 1, LV_GRID_ALIGN_CENTER, 1, 1);
-  lv_obj_set_grid_cell(z_down_btn.get_container(), LV_GRID_ALIGN_CENTER, 3, 1, LV_GRID_ALIGN_CENTER, 1, 1);
-  lv_obj_set_grid_cell(motoroff_btn.get_container(), LV_GRID_ALIGN_CENTER, 4, 1, LV_GRID_ALIGN_CENTER, 1, 1);
-    
-  lv_obj_set_grid_cell(distance_selector.get_container(), LV_GRID_ALIGN_CENTER, 0, 5, LV_GRID_ALIGN_CENTER, 2, 1);
+  lv_obj_set_grid_cell(x_down_btn.get_container(), LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(y_down_btn.get_container(), LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(x_up_btn.get_container(), LV_GRID_ALIGN_STRETCH, 2, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(z_down_btn.get_container(), LV_GRID_ALIGN_STRETCH, 3, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(motoroff_btn.get_container(), LV_GRID_ALIGN_STRETCH, 4, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
 
-  lv_obj_add_flag(back_btn.get_container(), LV_OBJ_FLAG_FLOATING);  
+  lv_obj_set_grid_cell(speed_selector.get_container(), LV_GRID_ALIGN_STRETCH, 0, 4, LV_GRID_ALIGN_STRETCH, 2, 1);
+  lv_obj_set_grid_cell(distance_selector.get_container(), LV_GRID_ALIGN_STRETCH, 0, 4, LV_GRID_ALIGN_STRETCH, 3, 1);
+
+  lv_obj_add_flag(back_btn.get_container(), LV_OBJ_FLAG_FLOATING);
   lv_obj_align(back_btn.get_container(), LV_ALIGN_BOTTOM_RIGHT, 10, 0);
 
   ws.register_notify_update(this);
@@ -161,9 +163,12 @@ void HomingPanel::foreground() {
 }
 
 void HomingPanel::handle_callback(lv_event_t *event) {
-  lv_obj_t *btn = lv_event_get_current_target(event);  
+  lv_obj_t *btn = lv_event_get_current_target(event);
   const char * distance = lv_btnmatrix_get_btn_text(distance_selector.get_selector(),
 						    distance_selector.get_selected_idx());
+  const char* speed = lv_btnmatrix_get_btn_text(speed_selector.get_selector(),
+    speed_selector.get_selected_idx());
+  int speed_mm_min = static_cast<int>(std::round(std::stod(speed) * 60));
   std::string move_op;
 
   if (btn == home_all_btn.get_container()) {
@@ -178,32 +183,32 @@ void HomingPanel::handle_callback(lv_event_t *event) {
   }
   else if (btn == y_up_btn.get_container()) {
     spdlog::debug("y up pressed");
-    move_op = fmt::format("G0 Y+{} F1200", distance);
+    move_op = fmt::format("G0 Y+{} F{}", distance, speed_mm_min);
 
   }
   else if (btn == y_down_btn.get_container()) {
     spdlog::debug("y down pressed");
-    move_op = fmt::format("G0 Y-{} F1200", distance);
+    move_op = fmt::format("G0 Y-{} F{}", distance, speed_mm_min);
 
   }
   else if (btn == x_up_btn.get_container()) {
     spdlog::debug("x up pressed");
-    move_op = fmt::format("G0 X+{} F1200", distance);
+    move_op = fmt::format("G0 X+{} F{}", distance, speed_mm_min);
 
   }
   else if (btn == x_down_btn.get_container()) {
     spdlog::debug("x down pressed");
-    move_op = fmt::format("G0 X-{} F1200", distance);
+    move_op = fmt::format("G0 X-{} F{}", distance, speed_mm_min);
 
   }
   else if (btn == z_up_btn.get_container()) {
     spdlog::debug("z up pressed");
-    move_op = fmt::format("G0 Z+{} F1200", distance);
+    move_op = fmt::format("G0 Z+{} F{}", distance, speed_mm_min);
 
   }
   else if (btn == z_down_btn.get_container()) {
     spdlog::debug("z down pressed");
-    move_op = fmt::format("G0 Z-{} F1200", distance);
+    move_op = fmt::format("G0 Z-{} F{}", distance, speed_mm_min);
 
   }
   else if (btn == emergency_btn.get_container()) {
@@ -223,8 +228,10 @@ void HomingPanel::handle_callback(lv_event_t *event) {
   }
 
   if (move_op.size() > 0) {
-    // ws.gcode_script("G91");
-    ws.gcode_script(fmt::format("G91\n{}", move_op));
+    std::string gcode = fmt::format(
+      "SAVE_GCODE_STATE NAME=_guppy_movement\nG91\n{}\nG90\nRESTORE_GCODE_STATE NAME=_guppy_movement",
+      move_op);
+    ws.gcode_script(gcode);
   }
 }
 
@@ -233,4 +240,11 @@ void HomingPanel::handle_selector_cb(lv_event_t *event) {
   uint32_t idx = lv_btnmatrix_get_selected_btn(obj);
   distance_selector.set_selected_idx(idx);
   spdlog::debug("selector move distance index {}", idx);
+}
+
+void HomingPanel::handle_speed_selector_cb(lv_event_t *event) {
+  lv_obj_t* obj = lv_event_get_target(event);
+  uint32_t idx = lv_btnmatrix_get_selected_btn(obj);
+  speed_selector.set_selected_idx(idx);
+  spdlog::debug("selector move speed index {}", idx);
 }

--- a/src/homing_panel.h
+++ b/src/homing_panel.h
@@ -19,7 +19,8 @@ class HomingPanel : public NotifyConsumer {
   void foreground();
   void handle_callback(lv_event_t *event);
   void handle_selector_cb(lv_event_t *event);
-  
+  void handle_speed_selector_cb(lv_event_t* event);
+
   static void _handle_callback(lv_event_t *event) {
     HomingPanel *panel = (HomingPanel*)event->user_data;
     panel->handle_callback(event);
@@ -28,6 +29,12 @@ class HomingPanel : public NotifyConsumer {
   static void _handle_selector_cb(lv_event_t *event) {
     HomingPanel *panel = (HomingPanel*)event->user_data;
     panel->handle_selector_cb(event);
+  };
+
+  static void _handle_speed_selector_cb(lv_event_t* event)
+  {
+    HomingPanel* panel = (HomingPanel*)event->user_data;
+    panel->handle_speed_selector_cb(event);
   };
 
  private:
@@ -44,6 +51,7 @@ class HomingPanel : public NotifyConsumer {
   ButtonContainer emergency_btn;
   ButtonContainer motoroff_btn;
   ButtonContainer back_btn;
+  Selector speed_selector;
   Selector distance_selector;
 };
 

--- a/src/homing_panel.h
+++ b/src/homing_panel.h
@@ -10,34 +10,34 @@
 #include <mutex>
 
 class HomingPanel : public NotifyConsumer {
- public:
+public:
   HomingPanel(KWebSocketClient &ws, std::mutex &);
   ~HomingPanel();
 
   void consume(json &data);
-  lv_obj_t * get_container();
+  lv_obj_t *get_container();
   void foreground();
   void handle_callback(lv_event_t *event);
   void handle_selector_cb(lv_event_t *event);
-  void handle_speed_selector_cb(lv_event_t* event);
+  void handle_speed_selector_cb(lv_event_t *event);
 
   static void _handle_callback(lv_event_t *event) {
-    HomingPanel *panel = (HomingPanel*)event->user_data;
+    HomingPanel *panel = (HomingPanel *)event->user_data;
     panel->handle_callback(event);
   };
 
   static void _handle_selector_cb(lv_event_t *event) {
-    HomingPanel *panel = (HomingPanel*)event->user_data;
+    HomingPanel *panel = (HomingPanel *)event->user_data;
     panel->handle_selector_cb(event);
   };
 
-  static void _handle_speed_selector_cb(lv_event_t* event)
+  static void _handle_speed_selector_cb(lv_event_t *event)
   {
-    HomingPanel* panel = (HomingPanel*)event->user_data;
+    HomingPanel *panel = (HomingPanel *)event->user_data;
     panel->handle_speed_selector_cb(event);
   };
 
- private:
+private:
   KWebSocketClient &ws;
   lv_obj_t *homing_cont;
   ButtonContainer home_all_btn;

--- a/src/inputshaper_panel.cpp
+++ b/src/inputshaper_panel.cpp
@@ -31,19 +31,19 @@ InputShaperPanel::InputShaperPanel(KWebSocketClient &c, std::mutex &l)
   , lv_lock(l)
   , cont(lv_obj_create(lv_scr_act()))
 
-    // xgraph
+  // xgraph
   , xgraph_cont(lv_obj_create(cont))
   , xgraph(lv_img_create(xgraph_cont))
   , xoutput(lv_label_create(cont))
   , xspinner(lv_spinner_create(cont, 1000, 60))
 
-    // ygraph
+  // ygraph
   , ygraph_cont(lv_obj_create(cont))
   , ygraph(lv_img_create(ygraph_cont))
   , youtput(lv_label_create(cont))
   , yspinner(lv_spinner_create(cont, 1000, 60))
 
-    // x controls
+  // x controls
   , xcontrol(lv_obj_create(cont))
   , xaxis_label(lv_label_create(xcontrol))
   , x_switch(lv_switch_create(xcontrol))
@@ -52,7 +52,7 @@ InputShaperPanel::InputShaperPanel(KWebSocketClient &c, std::mutex &l)
   , xlabel(lv_label_create(xslider_cont))
   , xshaper_dd(lv_dropdown_create(xcontrol))
 
-    // y controls
+  // y controls
   , ycontrol(lv_obj_create(cont))
   , yaxis_label(lv_label_create(ycontrol))
   , y_switch(lv_switch_create(ycontrol))
@@ -68,11 +68,11 @@ InputShaperPanel::InputShaperPanel(KWebSocketClient &c, std::mutex &l)
   , calibrate_btn(button_cont, &resume, "Calibrate", &InputShaperPanel::_handle_callback, this)
   , save_btn(button_cont, &sd_img, "Save", &InputShaperPanel::_handle_callback, this)
   , emergency_btn(button_cont, &emergency, "Stop", &InputShaperPanel::_handle_callback, this,
-		  "Do you want to emergency stop?",
-		  [&c]() {
-		    spdlog::debug("emergency stop pressed");
-		    c.send_jsonrpc("printer.emergency_stop");
-		  })
+    "Do you want to emergency stop?",
+    [&c]() {
+      spdlog::debug("emergency stop pressed");
+      c.send_jsonrpc("printer.emergency_stop");
+    })
   , back_btn(cont, &back, "Back", &InputShaperPanel::_handle_callback, this)
   , ximage_fullsized(false)
   , yimage_fullsized(false)
@@ -91,7 +91,7 @@ InputShaperPanel::InputShaperPanel(KWebSocketClient &c, std::mutex &l)
   lv_obj_add_flag(xgraph_cont, LV_OBJ_FLAG_CLICKABLE);
   lv_obj_clear_flag(xgraph_cont, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_add_event_cb(xgraph_cont, &InputShaperPanel::_handle_image_clicked,
-		      LV_EVENT_CLICKED, this);
+    LV_EVENT_CLICKED, this);
 
   graph_label = lv_label_create(ygraph_cont);
   lv_label_set_text(graph_label, "Y Frequency Response");
@@ -101,7 +101,7 @@ InputShaperPanel::InputShaperPanel(KWebSocketClient &c, std::mutex &l)
   lv_obj_add_flag(ygraph_cont, LV_OBJ_FLAG_CLICKABLE);
   lv_obj_clear_flag(ygraph_cont, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_add_event_cb(ygraph_cont, &InputShaperPanel::_handle_image_clicked,
-		      LV_EVENT_CLICKED, this);
+    LV_EVENT_CLICKED, this);
 
   // graphs
   lv_img_set_zoom(xgraph, 95);
@@ -177,7 +177,7 @@ InputShaperPanel::InputShaperPanel(KWebSocketClient &c, std::mutex &l)
   lv_slider_set_range(xslider, 0, 1400);
 
   lv_obj_add_event_cb(xslider, &InputShaperPanel::_handle_update_slider,
-		      LV_EVENT_VALUE_CHANGED, this);
+    LV_EVENT_VALUE_CHANGED, this);
 
 
   lv_obj_align_to(xlabel, xslider, LV_ALIGN_OUT_BOTTOM_MID, 0, 35 * scale);
@@ -205,7 +205,7 @@ InputShaperPanel::InputShaperPanel(KWebSocketClient &c, std::mutex &l)
   lv_slider_set_range(yslider, 0, 1400);
 
   lv_obj_add_event_cb(yslider, &InputShaperPanel::_handle_update_slider,
-		      LV_EVENT_VALUE_CHANGED, this);
+    LV_EVENT_VALUE_CHANGED, this);
 
   lv_obj_align_to(ylabel, yslider, LV_ALIGN_OUT_BOTTOM_MID, 0, 35 * scale);
   lv_label_set_text(ylabel, "0 Hz");
@@ -242,8 +242,8 @@ InputShaperPanel::InputShaperPanel(KWebSocketClient &c, std::mutex &l)
   // TODO: show only register when issuing macros inputshaper cares about, then unregister after.
   // ws.register_gcode_resp([this](json& d) { this->handle_macro_response(d); });
   ws.register_method_callback("notify_gcode_response",
-			      "InputShaperPanel",
-			      [this](json& d) { this->handle_macro_response(d); });
+    "InputShaperPanel",
+    [this](json &d) { this->handle_macro_response(d); });
 }
 
 InputShaperPanel::~InputShaperPanel() {
@@ -309,7 +309,7 @@ void InputShaperPanel::handle_callback(lv_event_t *event) {
       // free src
       lv_img_set_src(xgraph, NULL);
       // hack to color in empty space.
-      ((lv_img_t*)xgraph)->src_type = LV_IMG_SRC_SYMBOL;
+      ((lv_img_t *)xgraph)->src_type = LV_IMG_SRC_SYMBOL;
 
       lv_label_set_text(xoutput, "");
       lv_obj_add_flag(xgraph_cont, LV_OBJ_FLAG_HIDDEN);
@@ -324,7 +324,7 @@ void InputShaperPanel::handle_callback(lv_event_t *event) {
       // free src
       lv_img_set_src(ygraph, NULL);
       // hack to color in empty space.
-      ((lv_img_t*)ygraph)->src_type = LV_IMG_SRC_SYMBOL;
+      ((lv_img_t *)ygraph)->src_type = LV_IMG_SRC_SYMBOL;
 
       lv_label_set_text(youtput, "");
       lv_obj_add_flag(ygraph_cont, LV_OBJ_FLAG_HIDDEN);
@@ -346,7 +346,7 @@ void InputShaperPanel::handle_callback(lv_event_t *event) {
     lv_dropdown_get_selected_str(yshaper_dd, ybuf, sizeof(ybuf));
 
     ws.gcode_script(fmt::format("SAVE_INPUT_SHAPER SHAPER_FREQ_X={} SHAPER_TYPE_X={} SHAPER_FREQ_Y={} SHAPER_TYPE_Y={}\nSAVE_CONFIG",
-				xhz, xbuf, yhz, ybuf));
+      xhz, xbuf, yhz, ybuf));
 
   } else if (btn == back_btn.get_container()) {
     lv_obj_move_background(cont);
@@ -368,69 +368,69 @@ void InputShaperPanel::handle_macro_response(json &j) {
       auto &axis_png = res["/png"_json_pointer];
 
       if (!axis_log.is_null()) {
-	std::string fn = axis_log.template get<std::string>();
-	if (X_DATA == fn) {
-	  if (graph_requested && !axis_png.is_null()) {
-	    spdlog::trace("found generated x freq png");
-	    auto config_root = KUtils::get_root_path("config");
-	    auto png_path = fmt::format("{}/{}", config_root.length() > 0 ? config_root : "/tmp" , X_PNG);
+        std::string fn = axis_log.template get<std::string>();
+        if (X_DATA == fn) {
+          if (graph_requested && !axis_png.is_null()) {
+            spdlog::trace("found generated x freq png");
+            auto config_root = KUtils::get_root_path("config");
+            auto png_path = fmt::format("{}/{}", config_root.length() > 0 ? config_root : "/tmp", X_PNG);
 
-	    png_path =
-	      fmt::format("A:{}", KUtils::is_running_local()
-			  ? png_path
-			  : KUtils::download_file("config", X_PNG, Config::get_instance()->get_thumbnail_path()));
+            png_path =
+              fmt::format("A:{}", KUtils::is_running_local()
+                ? png_path
+                : KUtils::download_file("config", X_PNG, Config::get_instance()->get_thumbnail_path()));
 
-	    spdlog::trace("x freq png path {}", png_path);
+            spdlog::trace("x freq png path {}", png_path);
 
-	    lv_label_set_text(xoutput, "");
-	    lv_img_set_src(xgraph, png_path.c_str());
-	    lv_obj_clear_flag(xgraph_cont, LV_OBJ_FLAG_HIDDEN);
-	    set_shaper_detail(res, NULL, xslider, xlabel, xshaper_dd);
-	    lv_obj_move_foreground(xgraph_cont);
-	  } else {
-	    set_shaper_detail(res, xoutput, xslider, xlabel, xshaper_dd);
-	    lv_obj_move_foreground(xoutput);
-	  }
+            lv_label_set_text(xoutput, "");
+            lv_img_set_src(xgraph, png_path.c_str());
+            lv_obj_clear_flag(xgraph_cont, LV_OBJ_FLAG_HIDDEN);
+            set_shaper_detail(res, NULL, xslider, xlabel, xshaper_dd);
+            lv_obj_move_foreground(xgraph_cont);
+          } else {
+            set_shaper_detail(res, xoutput, xslider, xlabel, xshaper_dd);
+            lv_obj_move_foreground(xoutput);
+          }
 
-	  lv_obj_add_flag(xspinner, LV_OBJ_FLAG_HIDDEN);
-	  lv_obj_move_background(xspinner);
+          lv_obj_add_flag(xspinner, LV_OBJ_FLAG_HIDDEN);
+          lv_obj_move_background(xspinner);
 
-	} else if (Y_DATA == fn) {
-	  if (graph_requested && !axis_png.is_null()) {
-	    spdlog::trace("found generated y freq png");
-	    auto config_root = KUtils::get_root_path("config");
-	    auto png_path = fmt::format("{}/{}", config_root.length() > 0 ? config_root : "/tmp" , Y_PNG);
+        } else if (Y_DATA == fn) {
+          if (graph_requested && !axis_png.is_null()) {
+            spdlog::trace("found generated y freq png");
+            auto config_root = KUtils::get_root_path("config");
+            auto png_path = fmt::format("{}/{}", config_root.length() > 0 ? config_root : "/tmp", Y_PNG);
 
-	    png_path =
-	      fmt::format("A:{}", KUtils::is_running_local()
-			  ? png_path
-			  : KUtils::download_file("config", Y_PNG, Config::get_instance()->get_thumbnail_path()));
+            png_path =
+              fmt::format("A:{}", KUtils::is_running_local()
+                ? png_path
+                : KUtils::download_file("config", Y_PNG, Config::get_instance()->get_thumbnail_path()));
 
-	    spdlog::trace("y freq png path {}", png_path);
+            spdlog::trace("y freq png path {}", png_path);
 
-	    lv_label_set_text(youtput, "");
-	    lv_img_set_src(ygraph, png_path.c_str());
-	    lv_obj_clear_flag(ygraph_cont, LV_OBJ_FLAG_HIDDEN);
-	    set_shaper_detail(res, NULL, yslider, ylabel, yshaper_dd);
-	    lv_obj_move_foreground(ygraph_cont);
-	  } else {
-	    set_shaper_detail(res, youtput, yslider, ylabel, yshaper_dd);
-	    lv_obj_move_foreground(youtput);
-	  }
+            lv_label_set_text(youtput, "");
+            lv_img_set_src(ygraph, png_path.c_str());
+            lv_obj_clear_flag(ygraph_cont, LV_OBJ_FLAG_HIDDEN);
+            set_shaper_detail(res, NULL, yslider, ylabel, yshaper_dd);
+            lv_obj_move_foreground(ygraph_cont);
+          } else {
+            set_shaper_detail(res, youtput, yslider, ylabel, yshaper_dd);
+            lv_obj_move_foreground(youtput);
+          }
 
-	  lv_obj_add_flag(yspinner, LV_OBJ_FLAG_HIDDEN);
-	  lv_obj_move_background(yspinner);
-	}
+          lv_obj_add_flag(yspinner, LV_OBJ_FLAG_HIDDEN);
+          lv_obj_move_background(yspinner);
+        }
       }
 
     } else if ("// Resonances data written to " Y_DATA " file" == resp) {
       auto config_root = KUtils::get_root_path("config");
       auto screen_width = (double)lv_disp_get_physical_hor_res(NULL) / 100.0;
       auto screen_height = (double)lv_disp_get_physical_ver_res(NULL) / 100.0;
-      auto png_path = fmt::format("{}/{}", config_root.length() > 0 ? config_root : "/tmp" , Y_PNG);
+      auto png_path = fmt::format("{}/{}", config_root.length() > 0 ? config_root : "/tmp", Y_PNG);
       std::string arg = graph_requested
-	? fmt::format("{} -o {} -w {} -l {}", Y_DATA, png_path, screen_width, screen_height)
-	: Y_DATA;
+        ? fmt::format("{} -o {} -w {} -l {}", Y_DATA, png_path, screen_width, screen_height)
+        : Y_DATA;
 
       ws.gcode_script(fmt::format("RUN_SHELL_COMMAND CMD=guppy_input_shaper PARAMS={:?}", arg));
 
@@ -438,10 +438,10 @@ void InputShaperPanel::handle_macro_response(json &j) {
       auto config_root = KUtils::get_root_path("config");
       auto screen_width = (double)lv_disp_get_physical_hor_res(NULL) / 100.0;
       auto screen_height = (double)lv_disp_get_physical_ver_res(NULL) / 100.0;
-      auto png_path = fmt::format("{}/{}", config_root.length() > 0 ? config_root : "/tmp" , X_PNG);
+      auto png_path = fmt::format("{}/{}", config_root.length() > 0 ? config_root : "/tmp", X_PNG);
       std::string arg = graph_requested
-	? fmt::format("{} -o {} -w {} -l {}", X_DATA, png_path, screen_width, screen_height)
-	: X_DATA;
+        ? fmt::format("{} -o {} -w {} -l {}", X_DATA, png_path, screen_width, screen_height)
+        : X_DATA;
 
       ws.gcode_script(fmt::format("RUN_SHELL_COMMAND CMD=guppy_input_shaper PARAMS={:?}", arg));
     }
@@ -455,57 +455,57 @@ void InputShaperPanel::handle_image_clicked(lv_event_t *e) {
 
     if (clicked == xgraph_cont) {
       if (yimage_fullsized) {
-	lv_obj_invalidate(ygraph);
-	lv_img_set_zoom(ygraph, 150);
-	yimage_fullsized = false;
-	lv_obj_set_size(ygraph_cont, LV_PCT(40), LV_PCT(45));
-	lv_obj_clear_flag(ygraph_cont, LV_OBJ_FLAG_FLOATING);
+        lv_obj_invalidate(ygraph);
+        lv_img_set_zoom(ygraph, 150);
+        yimage_fullsized = false;
+        lv_obj_set_size(ygraph_cont, LV_PCT(40), LV_PCT(45));
+        lv_obj_clear_flag(ygraph_cont, LV_OBJ_FLAG_FLOATING);
 
-	// lv_obj_set_size(ygraph_cont, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
+        // lv_obj_set_size(ygraph_cont, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
       }
 
       lv_obj_invalidate(xgraph);
 
       if (ximage_fullsized) {
-	lv_img_set_zoom(xgraph, 95);
-	lv_obj_set_size(xgraph_cont, LV_PCT(40), LV_PCT(45));
-	lv_obj_clear_flag(xgraph_cont, LV_OBJ_FLAG_FLOATING);
+        lv_img_set_zoom(xgraph, 95);
+        lv_obj_set_size(xgraph_cont, LV_PCT(40), LV_PCT(45));
+        lv_obj_clear_flag(xgraph_cont, LV_OBJ_FLAG_FLOATING);
 
-	// lv_obj_set_size(xgraph_cont, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
+        // lv_obj_set_size(xgraph_cont, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
 
       } else {
-	lv_img_set_zoom(xgraph, LV_IMG_ZOOM_NONE);
-	lv_obj_add_flag(xgraph_cont, LV_OBJ_FLAG_FLOATING);
-	lv_obj_set_size(xgraph_cont, LV_PCT(100), LV_PCT(100));
+        lv_img_set_zoom(xgraph, LV_IMG_ZOOM_NONE);
+        lv_obj_add_flag(xgraph_cont, LV_OBJ_FLAG_FLOATING);
+        lv_obj_set_size(xgraph_cont, LV_PCT(100), LV_PCT(100));
       }
       lv_obj_move_foreground(xgraph_cont);
       ximage_fullsized = !ximage_fullsized;
 
     } else if (clicked == ygraph_cont) {
       if (ximage_fullsized) {
-	lv_obj_invalidate(xgraph);
-	lv_img_set_zoom(xgraph, 150);
-	ximage_fullsized = false;
-	// lv_obj_set_size(xgraph_cont, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
-	lv_obj_set_size(xgraph_cont, LV_PCT(40), LV_PCT(45));
-	lv_obj_clear_flag(xgraph_cont, LV_OBJ_FLAG_FLOATING);
+        lv_obj_invalidate(xgraph);
+        lv_img_set_zoom(xgraph, 150);
+        ximage_fullsized = false;
+        // lv_obj_set_size(xgraph_cont, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
+        lv_obj_set_size(xgraph_cont, LV_PCT(40), LV_PCT(45));
+        lv_obj_clear_flag(xgraph_cont, LV_OBJ_FLAG_FLOATING);
 
       }
 
       lv_obj_invalidate(ygraph);
 
       if (yimage_fullsized) {
-	lv_img_set_zoom(ygraph, 95);
-	// lv_obj_set_size(ygraph_cont, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
-	lv_obj_set_size(ygraph_cont, LV_PCT(40), LV_PCT(45));
-	lv_obj_clear_flag(ygraph_cont, LV_OBJ_FLAG_FLOATING);
+        lv_img_set_zoom(ygraph, 95);
+        // lv_obj_set_size(ygraph_cont, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
+        lv_obj_set_size(ygraph_cont, LV_PCT(40), LV_PCT(45));
+        lv_obj_clear_flag(ygraph_cont, LV_OBJ_FLAG_FLOATING);
 
       } else {
-	lv_img_set_zoom(ygraph, LV_IMG_ZOOM_NONE);
-	lv_obj_set_size(ygraph_cont, LV_PCT(100), LV_PCT(100));
+        lv_img_set_zoom(ygraph, LV_IMG_ZOOM_NONE);
+        lv_obj_set_size(ygraph_cont, LV_PCT(100), LV_PCT(100));
 
-	// floating hacks (free child from grid) around the grid layout alignment
-	lv_obj_add_flag(ygraph_cont, LV_OBJ_FLAG_FLOATING);
+        // floating hacks (free child from grid) around the grid layout alignment
+        lv_obj_add_flag(ygraph_cont, LV_OBJ_FLAG_FLOATING);
 
       }
       lv_obj_move_foreground(ygraph_cont);
@@ -517,11 +517,11 @@ void InputShaperPanel::handle_image_clicked(lv_event_t *e) {
 void InputShaperPanel::handle_update_slider(lv_event_t *e) {
   const lv_event_code_t code = lv_event_get_code(e);
   if (code == LV_EVENT_VALUE_CHANGED) {
-    lv_obj_t * obj = lv_event_get_target(e);
+    lv_obj_t *obj = lv_event_get_target(e);
     double hz = (double)lv_slider_get_value(obj);
     lv_slider_set_value(obj, hz, LV_ANIM_OFF);
     if (obj == xslider) {
-      lv_label_set_text(xlabel, fmt::format("{} hz", hz / 10.0 ).c_str());
+      lv_label_set_text(xlabel, fmt::format("{} hz", hz / 10.0).c_str());
     } else if (obj == yslider) {
       lv_label_set_text(ylabel, fmt::format("{} hz", hz / 10.0).c_str());
     }
@@ -529,15 +529,15 @@ void InputShaperPanel::handle_update_slider(lv_event_t *e) {
 }
 
 uint32_t InputShaperPanel::find_shaper_index(const std::vector<std::string> &s,
-					     const std::string &shaper) {
+  const std::string &shaper) {
   return std::distance(s.cbegin(), std::find(s.cbegin(), s.cend(), shaper));
 }
 
 void InputShaperPanel::set_shaper_detail(json &res,
-					 lv_obj_t *label,
-					 lv_obj_t *slider,
-					 lv_obj_t *slider_label,
-					 lv_obj_t *dd) {
+  lv_obj_t *label,
+  lv_obj_t *slider,
+  lv_obj_t *slider_label,
+  lv_obj_t *dd) {
   auto &shapers_resp = res["/shapers"_json_pointer];
   if (!shapers_resp.is_null()) {
     std::vector<std::string> shaper_details;
@@ -545,7 +545,7 @@ void InputShaperPanel::set_shaper_detail(json &res,
     if (!best_shaper.is_null()) {
       auto bs_name = best_shaper.template get<std::string>();
       double f = shapers_resp[bs_name]["freq"]
-	.template get<double>();
+        .template get<double>();
       shaper_details.push_back(fmt::format("Best shaper is {} @ {:.2f} Hz\n", bs_name, f));
 
       uint32_t idx = find_shaper_index(shapers, bs_name);
@@ -557,15 +557,15 @@ void InputShaperPanel::set_shaper_detail(json &res,
 
     if (label != NULL) {
       shaper_details.push_back(fmt::format("{:^8}\t{:^4}\t{:^5}\t{:^5}\t{:^5}",
-					   "Shaper", "Hz", "Vibr", "Smt", "MaxAcl"));
+        "Shaper", "Hz", "Vibr", "Smt", "MaxAcl"));
       for (auto &el : shapers_resp.items()) {
-	shaper_details.push_back(
-				 fmt::format("{:<8}\t{:.1f}\t{:.1f}%\t{:.3f}\t{:>}",
-					     el.key(),
-					     el.value()["freq"].template get<double>(),
-					     el.value()["vib"].template get<double>(),
-					     el.value()["smooth"].template get<double>(),
-					     el.value()["max_acel"].template get<double>()));
+        shaper_details.push_back(
+          fmt::format("{:<8}\t{:.1f}\t{:.1f}%\t{:.3f}\t{:>}",
+            el.key(),
+            el.value()["freq"].template get<double>(),
+            el.value()["vib"].template get<double>(),
+            el.value()["smooth"].template get<double>(),
+            el.value()["max_acel"].template get<double>()));
       }
 
       lv_label_set_text(label, fmt::format("{}", fmt::join(shaper_details, "\n")).c_str());

--- a/src/inputshaper_panel.cpp
+++ b/src/inputshaper_panel.cpp
@@ -43,7 +43,7 @@ InputShaperPanel::InputShaperPanel(KWebSocketClient &c, std::mutex &l)
   , youtput(lv_label_create(cont))
   , yspinner(lv_spinner_create(cont, 1000, 60))
 
-    // x controls    
+    // x controls
   , xcontrol(lv_obj_create(cont))
   , xaxis_label(lv_label_create(xcontrol))
   , x_switch(lv_switch_create(xcontrol))
@@ -60,7 +60,7 @@ InputShaperPanel::InputShaperPanel(KWebSocketClient &c, std::mutex &l)
   , yslider(lv_slider_create(yslider_cont))
   , ylabel(lv_label_create(yslider_cont))
   , yshaper_dd(lv_dropdown_create(ycontrol))
-    
+
   , button_cont(lv_obj_create(cont))
   , switch_cont(lv_obj_create(button_cont))
   , graph_switch_label(lv_label_create(switch_cont))
@@ -79,10 +79,10 @@ InputShaperPanel::InputShaperPanel(KWebSocketClient &c, std::mutex &l)
 {
   lv_obj_move_background(cont);
 
-  lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLLABLE);  
+  lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_size(cont, LV_PCT(100), LV_PCT(100));
   lv_obj_set_style_pad_all(cont, 0, 0);
-  
+
   lv_obj_t *graph_label = lv_label_create(xgraph_cont);
   lv_label_set_text(graph_label, "X Frequency Response");
   lv_obj_align(graph_label, LV_ALIGN_BOTTOM_MID, 0, 0);
@@ -94,7 +94,7 @@ InputShaperPanel::InputShaperPanel(KWebSocketClient &c, std::mutex &l)
 		      LV_EVENT_CLICKED, this);
 
   graph_label = lv_label_create(ygraph_cont);
-  lv_label_set_text(graph_label, "Y Frequency Response");  
+  lv_label_set_text(graph_label, "Y Frequency Response");
   lv_obj_align(graph_label, LV_ALIGN_BOTTOM_MID, 0, 0);
 
   lv_obj_set_style_pad_all(ygraph_cont, 0, 0);
@@ -106,14 +106,14 @@ InputShaperPanel::InputShaperPanel(KWebSocketClient &c, std::mutex &l)
   // graphs
   lv_img_set_zoom(xgraph, 95);
   lv_obj_center(xgraph);
-  // lv_img_set_src(xgraph, "A:/usr/data/printer_data/thumbnails/resonances_x.png");  
+  // lv_img_set_src(xgraph, "A:/usr/data/printer_data/thumbnails/resonances_x.png");
 
   lv_img_set_zoom(ygraph, 95);
   lv_obj_center(ygraph);
   // lv_img_set_src(ygraph, "A:/usr/data/printer_data/thumbnails/resonances_y.png");
-  
+
   lv_obj_set_size(ygraph_cont, LV_PCT(40), LV_PCT(45));
-  lv_obj_clear_flag(ygraph_cont, LV_OBJ_FLAG_SCROLLABLE);  
+  lv_obj_clear_flag(ygraph_cont, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_size(xgraph_cont, LV_PCT(40), LV_PCT(45));
   lv_obj_clear_flag(xgraph_cont, LV_OBJ_FLAG_SCROLLABLE);
 
@@ -131,19 +131,22 @@ InputShaperPanel::InputShaperPanel(KWebSocketClient &c, std::mutex &l)
   lv_obj_set_size(xspinner, 100, 100);
 
   lv_obj_add_flag(yspinner, LV_OBJ_FLAG_HIDDEN);
-  lv_obj_set_size(yspinner, 100, 100);  
+  lv_obj_set_size(yspinner, 100, 100);
 
   // buttons
   lv_obj_set_size(button_cont, LV_PCT(20), LV_PCT(100));
   lv_obj_clear_flag(button_cont, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_flex_flow(button_cont, LV_FLEX_FLOW_COLUMN);
-  lv_obj_set_flex_align(button_cont, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+  lv_obj_set_flex_align(button_cont, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+  lv_obj_set_flex_grow(calibrate_btn.get_container(), 1);
+  lv_obj_set_flex_grow(save_btn.get_container(), 1);
+  lv_obj_set_flex_grow(emergency_btn.get_container(), 1);
 
   lv_obj_set_size(switch_cont, LV_PCT(100), LV_SIZE_CONTENT);
   lv_obj_set_style_pad_row(switch_cont, 0, 0);
   lv_obj_set_flex_flow(switch_cont, LV_FLEX_FLOW_COLUMN);
   lv_obj_set_flex_align(switch_cont, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-  
+
   lv_obj_set_style_text_align(graph_switch_label, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_text(graph_switch_label, "Graph");
   lv_obj_set_width(graph_switch_label, LV_PCT(100));
@@ -168,18 +171,18 @@ InputShaperPanel::InputShaperPanel(KWebSocketClient &c, std::mutex &l)
   lv_obj_clear_flag(xslider_cont, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_size(xslider_cont, LV_PCT(53), LV_SIZE_CONTENT);
   lv_obj_set_style_pad_all(xslider_cont, 0, 0);
-  
+
   lv_obj_center(xslider);
   lv_obj_set_width(xslider, LV_PCT(85));
   lv_slider_set_range(xslider, 0, 1400);
 
   lv_obj_add_event_cb(xslider, &InputShaperPanel::_handle_update_slider,
 		      LV_EVENT_VALUE_CHANGED, this);
-  
+
 
   lv_obj_align_to(xlabel, xslider, LV_ALIGN_OUT_BOTTOM_MID, 0, 35 * scale);
   lv_label_set_text(xlabel, "0 Hz");
-  
+
   lv_dropdown_set_options(xshaper_dd, fmt::format("{}", fmt::join(shapers, "\n")).c_str());
 
   lv_obj_set_flex_flow(ycontrol, LV_FLEX_FLOW_ROW_WRAP);
@@ -193,17 +196,17 @@ InputShaperPanel::InputShaperPanel(KWebSocketClient &c, std::mutex &l)
   lv_label_set_text(yaxis_label, "Y Axis");
   lv_obj_add_state(y_switch, LV_STATE_CHECKED);
 
-  lv_obj_clear_flag(yslider_cont, LV_OBJ_FLAG_SCROLLABLE);    
+  lv_obj_clear_flag(yslider_cont, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_size(yslider_cont, LV_PCT(53), LV_SIZE_CONTENT);
   lv_obj_set_style_pad_all(yslider_cont, 0, 0);
-  
+
   lv_obj_center(yslider);
   lv_obj_set_width(yslider, LV_PCT(85));
   lv_slider_set_range(yslider, 0, 1400);
-  
+
   lv_obj_add_event_cb(yslider, &InputShaperPanel::_handle_update_slider,
 		      LV_EVENT_VALUE_CHANGED, this);
-  
+
   lv_obj_align_to(ylabel, yslider, LV_ALIGN_OUT_BOTTOM_MID, 0, 35 * scale);
   lv_label_set_text(ylabel, "0 Hz");
 
@@ -213,7 +216,7 @@ InputShaperPanel::InputShaperPanel(KWebSocketClient &c, std::mutex &l)
     LV_GRID_TEMPLATE_LAST};
   static lv_coord_t grid_main_col_dsc[] = {LV_GRID_FR(3), LV_GRID_FR(7), LV_GRID_FR(7),
     LV_GRID_TEMPLATE_LAST};
-  
+
   lv_obj_set_grid_dsc_array(cont, grid_main_col_dsc, grid_main_row_dsc);
 
   // row 1, col 2/3
@@ -233,9 +236,9 @@ InputShaperPanel::InputShaperPanel(KWebSocketClient &c, std::mutex &l)
   // row 1, col 1
   lv_obj_set_grid_cell(button_cont, LV_GRID_ALIGN_CENTER, 0, 1, LV_GRID_ALIGN_CENTER, 0, 3);
 
-  lv_obj_add_flag(back_btn.get_container(), LV_OBJ_FLAG_FLOATING);  
+  lv_obj_add_flag(back_btn.get_container(), LV_OBJ_FLAG_FLOATING);
   lv_obj_align(back_btn.get_container(), LV_ALIGN_BOTTOM_RIGHT, 0, -20);
-  
+
   // TODO: show only register when issuing macros inputshaper cares about, then unregister after.
   // ws.register_gcode_resp([this](json& d) { this->handle_macro_response(d); });
   ws.register_method_callback("notify_gcode_response",
@@ -268,13 +271,13 @@ void InputShaperPanel::foreground() {
       auto shaper = v.template get<std::string>();
       auto idx = find_shaper_index(shapers, shaper);
       lv_dropdown_set_selected(xshaper_dd, idx);
-    }    
+    }
 
     v = inputshaper["/shaper_freq_y"_json_pointer];
     if (!v.is_null()) {
       double hz = std::stod(v.template get<std::string>());
       lv_slider_set_value(yslider, hz * 10, LV_ANIM_OFF);
-      lv_label_set_text(ylabel, fmt::format("{} Hz", hz).c_str()); 
+      lv_label_set_text(ylabel, fmt::format("{} Hz", hz).c_str());
     }
 
     v = inputshaper["/shaper_type_y"_json_pointer];
@@ -284,7 +287,7 @@ void InputShaperPanel::foreground() {
       lv_dropdown_set_selected(yshaper_dd, idx);
     }
   }
-  
+
   lv_obj_move_foreground(cont);
 }
 
@@ -303,13 +306,13 @@ void InputShaperPanel::handle_callback(lv_event_t *event) {
       // ws.gcode_script(fmt::format("TEST_RESONANCES AXIS=X NAME=x FREQ_START={} FREQ_END={}\nM400", 5, 10));
       ws.gcode_script(fmt::format("TEST_RESONANCES AXIS=X NAME=x\nM400"));
 
-      // free src      
+      // free src
       lv_img_set_src(xgraph, NULL);
       // hack to color in empty space.
       ((lv_img_t*)xgraph)->src_type = LV_IMG_SRC_SYMBOL;
-      
+
       lv_label_set_text(xoutput, "");
-      lv_obj_add_flag(xgraph_cont, LV_OBJ_FLAG_HIDDEN);      
+      lv_obj_add_flag(xgraph_cont, LV_OBJ_FLAG_HIDDEN);
       lv_obj_clear_flag(xspinner, LV_OBJ_FLAG_HIDDEN);
       lv_obj_move_foreground(xspinner);
     }
@@ -322,8 +325,8 @@ void InputShaperPanel::handle_callback(lv_event_t *event) {
       lv_img_set_src(ygraph, NULL);
       // hack to color in empty space.
       ((lv_img_t*)ygraph)->src_type = LV_IMG_SRC_SYMBOL;
-      
-      lv_label_set_text(youtput, ""); 
+
+      lv_label_set_text(youtput, "");
       lv_obj_add_flag(ygraph_cont, LV_OBJ_FLAG_HIDDEN);
       lv_obj_clear_flag(yspinner, LV_OBJ_FLAG_HIDDEN);
       lv_obj_move_foreground(yspinner);
@@ -341,7 +344,7 @@ void InputShaperPanel::handle_callback(lv_event_t *event) {
 
     char ybuf[10];
     lv_dropdown_get_selected_str(yshaper_dd, ybuf, sizeof(ybuf));
-    
+
     ws.gcode_script(fmt::format("SAVE_INPUT_SHAPER SHAPER_FREQ_X={} SHAPER_TYPE_X={} SHAPER_FREQ_Y={} SHAPER_TYPE_Y={}\nSAVE_CONFIG",
 				xhz, xbuf, yhz, ybuf));
 
@@ -363,7 +366,7 @@ void InputShaperPanel::handle_macro_response(json &j) {
       auto res = json::parse(resp.substr(3));
       auto &axis_log = res["/logfile"_json_pointer];
       auto &axis_png = res["/png"_json_pointer];
-      
+
       if (!axis_log.is_null()) {
 	std::string fn = axis_log.template get<std::string>();
 	if (X_DATA == fn) {
@@ -372,13 +375,13 @@ void InputShaperPanel::handle_macro_response(json &j) {
 	    auto config_root = KUtils::get_root_path("config");
 	    auto png_path = fmt::format("{}/{}", config_root.length() > 0 ? config_root : "/tmp" , X_PNG);
 
-	    png_path = 
+	    png_path =
 	      fmt::format("A:{}", KUtils::is_running_local()
 			  ? png_path
 			  : KUtils::download_file("config", X_PNG, Config::get_instance()->get_thumbnail_path()));
 
 	    spdlog::trace("x freq png path {}", png_path);
-	      
+
 	    lv_label_set_text(xoutput, "");
 	    lv_img_set_src(xgraph, png_path.c_str());
 	    lv_obj_clear_flag(xgraph_cont, LV_OBJ_FLAG_HIDDEN);
@@ -388,7 +391,7 @@ void InputShaperPanel::handle_macro_response(json &j) {
 	    set_shaper_detail(res, xoutput, xslider, xlabel, xshaper_dd);
 	    lv_obj_move_foreground(xoutput);
 	  }
-	  
+
 	  lv_obj_add_flag(xspinner, LV_OBJ_FLAG_HIDDEN);
 	  lv_obj_move_background(xspinner);
 
@@ -398,7 +401,7 @@ void InputShaperPanel::handle_macro_response(json &j) {
 	    auto config_root = KUtils::get_root_path("config");
 	    auto png_path = fmt::format("{}/{}", config_root.length() > 0 ? config_root : "/tmp" , Y_PNG);
 
-	    png_path = 
+	    png_path =
 	      fmt::format("A:{}", KUtils::is_running_local()
 			  ? png_path
 			  : KUtils::download_file("config", Y_PNG, Config::get_instance()->get_thumbnail_path()));
@@ -456,26 +459,26 @@ void InputShaperPanel::handle_image_clicked(lv_event_t *e) {
 	lv_img_set_zoom(ygraph, 150);
 	yimage_fullsized = false;
 	lv_obj_set_size(ygraph_cont, LV_PCT(40), LV_PCT(45));
-	lv_obj_clear_flag(ygraph_cont, LV_OBJ_FLAG_FLOATING);	
-	
-	// lv_obj_set_size(ygraph_cont, LV_SIZE_CONTENT, LV_SIZE_CONTENT);	
+	lv_obj_clear_flag(ygraph_cont, LV_OBJ_FLAG_FLOATING);
+
+	// lv_obj_set_size(ygraph_cont, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
       }
-      
+
       lv_obj_invalidate(xgraph);
 
       if (ximage_fullsized) {
 	lv_img_set_zoom(xgraph, 95);
 	lv_obj_set_size(xgraph_cont, LV_PCT(40), LV_PCT(45));
-	lv_obj_clear_flag(xgraph_cont, LV_OBJ_FLAG_FLOATING);	
-	
-	// lv_obj_set_size(xgraph_cont, LV_SIZE_CONTENT, LV_SIZE_CONTENT);		
-	
+	lv_obj_clear_flag(xgraph_cont, LV_OBJ_FLAG_FLOATING);
+
+	// lv_obj_set_size(xgraph_cont, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
+
       } else {
 	lv_img_set_zoom(xgraph, LV_IMG_ZOOM_NONE);
-	lv_obj_add_flag(xgraph_cont, LV_OBJ_FLAG_FLOATING);	
+	lv_obj_add_flag(xgraph_cont, LV_OBJ_FLAG_FLOATING);
 	lv_obj_set_size(xgraph_cont, LV_PCT(100), LV_PCT(100));
       }
-      lv_obj_move_foreground(xgraph_cont);      
+      lv_obj_move_foreground(xgraph_cont);
       ximage_fullsized = !ximage_fullsized;
 
     } else if (clicked == ygraph_cont) {
@@ -485,10 +488,10 @@ void InputShaperPanel::handle_image_clicked(lv_event_t *e) {
 	ximage_fullsized = false;
 	// lv_obj_set_size(xgraph_cont, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
 	lv_obj_set_size(xgraph_cont, LV_PCT(40), LV_PCT(45));
-	lv_obj_clear_flag(xgraph_cont, LV_OBJ_FLAG_FLOATING);	
-	
+	lv_obj_clear_flag(xgraph_cont, LV_OBJ_FLAG_FLOATING);
+
       }
-      
+
       lv_obj_invalidate(ygraph);
 
       if (yimage_fullsized) {
@@ -520,7 +523,7 @@ void InputShaperPanel::handle_update_slider(lv_event_t *e) {
     if (obj == xslider) {
       lv_label_set_text(xlabel, fmt::format("{} hz", hz / 10.0 ).c_str());
     } else if (obj == yslider) {
-      lv_label_set_text(ylabel, fmt::format("{} hz", hz / 10.0).c_str());      
+      lv_label_set_text(ylabel, fmt::format("{} hz", hz / 10.0).c_str());
     }
   }
 }

--- a/src/main_panel.cpp
+++ b/src/main_panel.cpp
@@ -22,8 +22,8 @@ LV_FONT_DECLARE(materialdesign_font_40);
 #define SETTING_SYMBOL "\xF3\xB0\x92\x93"
 
 MainPanel::MainPanel(KWebSocketClient &websocket,
-		     std::mutex &lock,
-		     SpoolmanPanel &sm)
+  std::mutex &lock,
+  SpoolmanPanel &sm)
   : NotifyConsumer(lock)
   , ws(websocket)
   , homing_panel(ws, lock)
@@ -54,13 +54,13 @@ MainPanel::MainPanel(KWebSocketClient &websocket,
   , led_btn(main_cont, &light_img, "LED", &MainPanel::_handle_ledpanel_cb, this)
   , print_btn(main_cont, &print, "Print", &MainPanel::_handle_print_cb, this)
 {
-    lv_style_init(&style);
-    lv_style_set_img_recolor_opa(&style, LV_OPA_30);
-    lv_style_set_img_recolor(&style, lv_color_black());
-    lv_style_set_border_width(&style, 0);
-    lv_style_set_bg_color(&style, lv_palette_darken(LV_PALETTE_GREY, 4));
+  lv_style_init(&style);
+  lv_style_set_img_recolor_opa(&style, LV_OPA_30);
+  lv_style_set_img_recolor(&style, lv_color_black());
+  lv_style_set_border_width(&style, 0);
+  lv_style_set_bg_color(&style, lv_palette_darken(LV_PALETTE_GREY, 4));
 
-    ws.register_notify_update(this);
+  ws.register_notify_update(this);
 }
 
 MainPanel::~MainPanel() {
@@ -78,7 +78,7 @@ void MainPanel::subscribe() {
   print_panel.subscribe();
 }
 
-PrinterTunePanel& MainPanel::get_tune_panel() {
+PrinterTunePanel &MainPanel::get_tune_panel() {
   return printertune_panel;
 }
 
@@ -124,12 +124,12 @@ void MainPanel::consume(json &j) {
   }
 }
 
-static void scroll_begin_event(lv_event_t * e)
+static void scroll_begin_event(lv_event_t *e)
 {
   /*Disable the scroll animations. Triggered when a tab button is clicked */
   if (lv_event_get_code(e) == LV_EVENT_SCROLL_BEGIN) {
-    lv_anim_t * a = (lv_anim_t*)lv_event_get_param(e);
-    if(a)  a->time = 0;
+    lv_anim_t *a = (lv_anim_t *)lv_event_get_param(e);
+    if (a)  a->time = 0;
   }
 }
 
@@ -137,7 +137,7 @@ void MainPanel::create_panel() {
   lv_obj_clear_flag(lv_tabview_get_content(tabview), LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_add_event_cb(lv_tabview_get_content(tabview), scroll_begin_event, LV_EVENT_SCROLL_BEGIN, NULL);
 
-  lv_obj_t * tab_btns = lv_tabview_get_tab_btns(tabview);
+  lv_obj_t *tab_btns = lv_tabview_get_tab_btns(tabview);
   lv_obj_set_style_bg_color(tab_btns, lv_palette_main(LV_PALETTE_GREY), LV_STATE_CHECKED | LV_PART_ITEMS);
   lv_obj_set_style_outline_width(tab_btns, 0, LV_PART_ITEMS | LV_STATE_FOCUS_KEY | LV_STATE_FOCUS_KEY);
   lv_obj_set_style_border_side(tab_btns, 0, LV_PART_ITEMS | LV_STATE_CHECKED);
@@ -191,45 +191,45 @@ void MainPanel::handle_print_cb(lv_event_t *event) {
   }
 }
 
-void MainPanel::create_main(lv_obj_t * parent)
+void MainPanel::create_main(lv_obj_t *parent)
 {
-    lv_obj_set_flex_flow(parent, LV_FLEX_FLOW_ROW_WRAP);
+  lv_obj_set_flex_flow(parent, LV_FLEX_FLOW_ROW_WRAP);
 
-    static lv_coord_t grid_main_row_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
-    static lv_coord_t grid_main_col_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1),
-      LV_GRID_TEMPLATE_LAST};
+  static lv_coord_t grid_main_row_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
+  static lv_coord_t grid_main_col_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1),
+    LV_GRID_TEMPLATE_LAST};
 
-    lv_obj_clear_flag(main_cont, LV_OBJ_FLAG_SCROLLABLE);
-    lv_obj_set_height(main_cont, LV_PCT(100));
+  lv_obj_clear_flag(main_cont, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_height(main_cont, LV_PCT(100));
 
-    lv_obj_set_flex_grow(main_cont, 1);
-    lv_obj_set_grid_dsc_array(main_cont, grid_main_col_dsc, grid_main_row_dsc);
+  lv_obj_set_flex_grow(main_cont, 1);
+  lv_obj_set_grid_dsc_array(main_cont, grid_main_col_dsc, grid_main_row_dsc);
 
-    lv_obj_set_grid_cell(homing_btn.get_container(), LV_GRID_ALIGN_STRETCH, 2, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
-    lv_obj_set_grid_cell(extrude_btn.get_container(), LV_GRID_ALIGN_STRETCH, 3, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
-    lv_obj_set_grid_cell(action_btn.get_container(), LV_GRID_ALIGN_STRETCH, 2, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
-    lv_obj_set_grid_cell(led_btn.get_container(), LV_GRID_ALIGN_STRETCH, 3, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
-    lv_obj_set_grid_cell(print_btn.get_container(), LV_GRID_ALIGN_STRETCH, 2, 2, LV_GRID_ALIGN_STRETCH, 2, 1);
+  lv_obj_set_grid_cell(homing_btn.get_container(), LV_GRID_ALIGN_STRETCH, 2, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
+  lv_obj_set_grid_cell(extrude_btn.get_container(), LV_GRID_ALIGN_STRETCH, 3, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
+  lv_obj_set_grid_cell(action_btn.get_container(), LV_GRID_ALIGN_STRETCH, 2, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(led_btn.get_container(), LV_GRID_ALIGN_STRETCH, 3, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(print_btn.get_container(), LV_GRID_ALIGN_STRETCH, 2, 2, LV_GRID_ALIGN_STRETCH, 2, 1);
 
-    // lv_obj_clear_flag(temp_cont, LV_OBJ_FLAG_SCROLLABLE);
-    // lv_obj_set_size(temp_cont, LV_PCT(50), LV_PCT(50));
-    lv_obj_set_style_pad_all(temp_cont, 0, 0);
+  // lv_obj_clear_flag(temp_cont, LV_OBJ_FLAG_SCROLLABLE);
+  // lv_obj_set_size(temp_cont, LV_PCT(50), LV_PCT(50));
+  lv_obj_set_style_pad_all(temp_cont, 0, 0);
 
-    lv_obj_set_flex_flow(temp_cont, LV_FLEX_FLOW_COLUMN);
-    lv_obj_set_grid_cell(temp_cont, LV_GRID_ALIGN_STRETCH, 0, 2, LV_GRID_ALIGN_STRETCH, 0, 2);
+  lv_obj_set_flex_flow(temp_cont, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_grid_cell(temp_cont, LV_GRID_ALIGN_STRETCH, 0, 2, LV_GRID_ALIGN_STRETCH, 0, 2);
 
-    lv_obj_align(temp_chart, LV_ALIGN_CENTER, 0, 0);
-    lv_obj_set_width(temp_chart, LV_PCT(45));//, LV_PCT(40));
-    lv_obj_set_style_size(temp_chart, 0, LV_PART_INDICATOR);
+  lv_obj_align(temp_chart, LV_ALIGN_CENTER, 0, 0);
+  lv_obj_set_width(temp_chart, LV_PCT(45));//, LV_PCT(40));
+  lv_obj_set_style_size(temp_chart, 0, LV_PART_INDICATOR);
 
-    lv_chart_set_range(temp_chart, LV_CHART_AXIS_PRIMARY_Y, 0, 300);
-    lv_obj_set_grid_cell(temp_chart, LV_GRID_ALIGN_END, 0, 2, LV_GRID_ALIGN_STRETCH, 2, 1);
-    lv_chart_set_axis_tick(temp_chart, LV_CHART_AXIS_PRIMARY_Y, 0, 0, 6, 5, true, 50);
+  lv_chart_set_range(temp_chart, LV_CHART_AXIS_PRIMARY_Y, 0, 300);
+  lv_obj_set_grid_cell(temp_chart, LV_GRID_ALIGN_END, 0, 2, LV_GRID_ALIGN_STRETCH, 2, 1);
+  lv_chart_set_axis_tick(temp_chart, LV_CHART_AXIS_PRIMARY_Y, 0, 0, 6, 5, true, 50);
 
-    lv_chart_set_div_line_count(temp_chart, 3, 8);
-    lv_chart_set_point_count(temp_chart, 5000);
-    lv_chart_set_zoom_x(temp_chart, 5000);
-    lv_obj_scroll_to_x(temp_chart, LV_COORD_MAX, LV_ANIM_OFF);
+  lv_chart_set_div_line_count(temp_chart, 3, 8);
+  lv_chart_set_point_count(temp_chart, 5000);
+  lv_chart_set_zoom_x(temp_chart, 5000);
+  lv_obj_scroll_to_x(temp_chart, LV_COORD_MAX, LV_ANIM_OFF);
 }
 
 void MainPanel::create_sensors(json &temp_sensors) {
@@ -268,7 +268,7 @@ void MainPanel::create_sensors(json &temp_sensors) {
       }
     }
 
-    const void* sensor_img = &heater;
+    const void *sensor_img = &heater;
     if (key == "extruder") {
       sensor_img = &extruder;
     } else if (key == "heater_bed") {
@@ -278,9 +278,9 @@ void MainPanel::create_sensors(json &temp_sensors) {
     lv_chart_series_t *temp_series =
       lv_chart_add_series(temp_chart, color_code, LV_CHART_AXIS_PRIMARY_Y);
 
-    sensors.insert({ key, std::make_shared<SensorContainer>(ws, temp_cont, sensor_img, 150,
+    sensors.insert({key, std::make_shared<SensorContainer>(ws, temp_cont, sensor_img, 150,
       display_name.c_str(), color_code, controllable, false, numpad, sensor_name,
-      temp_chart, temp_series, type) });
+      temp_chart, temp_series, type)});
   }
 }
 

--- a/src/main_panel.cpp
+++ b/src/main_panel.cpp
@@ -28,7 +28,7 @@ MainPanel::MainPanel(KWebSocketClient &websocket,
   , ws(websocket)
   , homing_panel(ws, lock)
   , fan_panel(ws, lock)
-  , led_panel(ws, lock)    
+  , led_panel(ws, lock)
   , tabview(lv_tabview_create(lv_scr_act(), LV_DIR_LEFT, 60))
   , main_tab(lv_tabview_add_tab(tabview, HOME_SYMBOL))
   , macros_tab(lv_tabview_add_tab(tabview, MACROS_SYMBOL))
@@ -60,7 +60,7 @@ MainPanel::MainPanel(KWebSocketClient &websocket,
     lv_style_set_border_width(&style, 0);
     lv_style_set_bg_color(&style, lv_palette_darken(LV_PALETTE_GREY, 4));
 
-    ws.register_notify_update(this);    
+    ws.register_notify_update(this);
 }
 
 MainPanel::~MainPanel() {
@@ -106,7 +106,7 @@ void MainPanel::init(json &j) {
   printertune_panel.init(j);
 }
 
-void MainPanel::consume(json &j) {  
+void MainPanel::consume(json &j) {
   std::lock_guard<std::mutex> lock(lv_lock);
   for (const auto &el : sensors) {
     auto target_value = j[json::json_pointer(fmt::format("/params/0/{}/target", el.first))];
@@ -121,7 +121,7 @@ void MainPanel::consume(json &j) {
       el.second->update_series(value);
       el.second->update_value(value);
     }
-  }  
+  }
 }
 
 static void scroll_begin_event(lv_event_t * e)
@@ -136,7 +136,7 @@ static void scroll_begin_event(lv_event_t * e)
 void MainPanel::create_panel() {
   lv_obj_clear_flag(lv_tabview_get_content(tabview), LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_add_event_cb(lv_tabview_get_content(tabview), scroll_begin_event, LV_EVENT_SCROLL_BEGIN, NULL);
-  
+
   lv_obj_t * tab_btns = lv_tabview_get_tab_btns(tabview);
   lv_obj_set_style_bg_color(tab_btns, lv_palette_main(LV_PALETTE_GREY), LV_STATE_CHECKED | LV_PART_ITEMS);
   lv_obj_set_style_outline_width(tab_btns, 0, LV_PART_ITEMS | LV_STATE_FOCUS_KEY | LV_STATE_FOCUS_KEY);
@@ -152,7 +152,7 @@ void MainPanel::create_panel() {
   lv_obj_set_style_pad_all(setting_tab, 0, 0);
 
   create_main(main_tab);
-  
+
 }
 
 void MainPanel::handle_homing_cb(lv_event_t *event) {
@@ -203,27 +203,27 @@ void MainPanel::create_main(lv_obj_t * parent)
     lv_obj_set_height(main_cont, LV_PCT(100));
 
     lv_obj_set_flex_grow(main_cont, 1);
-    lv_obj_set_grid_dsc_array(main_cont, grid_main_col_dsc, grid_main_row_dsc);    
+    lv_obj_set_grid_dsc_array(main_cont, grid_main_col_dsc, grid_main_row_dsc);
 
-    lv_obj_set_grid_cell(homing_btn.get_container(), LV_GRID_ALIGN_CENTER, 2, 1, LV_GRID_ALIGN_CENTER, 0, 1);
-    lv_obj_set_grid_cell(extrude_btn.get_container(), LV_GRID_ALIGN_CENTER, 3, 1, LV_GRID_ALIGN_CENTER, 0, 1);
-    lv_obj_set_grid_cell(action_btn.get_container(), LV_GRID_ALIGN_CENTER, 2, 1, LV_GRID_ALIGN_CENTER, 1, 1);
-    lv_obj_set_grid_cell(led_btn.get_container(), LV_GRID_ALIGN_CENTER, 3, 1, LV_GRID_ALIGN_CENTER, 1, 1);
-    lv_obj_set_grid_cell(print_btn.get_container(), LV_GRID_ALIGN_CENTER, 2, 2, LV_GRID_ALIGN_CENTER, 2, 1);
+    lv_obj_set_grid_cell(homing_btn.get_container(), LV_GRID_ALIGN_STRETCH, 2, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
+    lv_obj_set_grid_cell(extrude_btn.get_container(), LV_GRID_ALIGN_STRETCH, 3, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
+    lv_obj_set_grid_cell(action_btn.get_container(), LV_GRID_ALIGN_STRETCH, 2, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+    lv_obj_set_grid_cell(led_btn.get_container(), LV_GRID_ALIGN_STRETCH, 3, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+    lv_obj_set_grid_cell(print_btn.get_container(), LV_GRID_ALIGN_STRETCH, 2, 2, LV_GRID_ALIGN_STRETCH, 2, 1);
 
-    lv_obj_clear_flag(temp_cont, LV_OBJ_FLAG_SCROLLABLE);
-    lv_obj_set_size(temp_cont, LV_PCT(50), LV_PCT(50));
+    // lv_obj_clear_flag(temp_cont, LV_OBJ_FLAG_SCROLLABLE);
+    // lv_obj_set_size(temp_cont, LV_PCT(50), LV_PCT(50));
     lv_obj_set_style_pad_all(temp_cont, 0, 0);
 
-    lv_obj_set_flex_flow(temp_cont, LV_FLEX_FLOW_ROW_WRAP);
-    lv_obj_set_grid_cell(temp_cont, LV_GRID_ALIGN_START, 0, 2, LV_GRID_ALIGN_CENTER, 0, 2);
-    
+    lv_obj_set_flex_flow(temp_cont, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_grid_cell(temp_cont, LV_GRID_ALIGN_STRETCH, 0, 2, LV_GRID_ALIGN_STRETCH, 0, 2);
+
     lv_obj_align(temp_chart, LV_ALIGN_CENTER, 0, 0);
-    lv_obj_set_size(temp_chart, LV_PCT(45), LV_PCT(40));
+    lv_obj_set_width(temp_chart, LV_PCT(45));//, LV_PCT(40));
     lv_obj_set_style_size(temp_chart, 0, LV_PART_INDICATOR);
 
     lv_chart_set_range(temp_chart, LV_CHART_AXIS_PRIMARY_Y, 0, 300);
-    lv_obj_set_grid_cell(temp_chart, LV_GRID_ALIGN_END, 0, 2, LV_GRID_ALIGN_END, 2, 1);
+    lv_obj_set_grid_cell(temp_chart, LV_GRID_ALIGN_END, 0, 2, LV_GRID_ALIGN_STRETCH, 2, 1);
     lv_chart_set_axis_tick(temp_chart, LV_CHART_AXIS_PRIMARY_Y, 0, 0, 6, 5, true, 50);
 
     lv_chart_set_div_line_count(temp_chart, 3, 8);
@@ -237,23 +237,36 @@ void MainPanel::create_sensors(json &temp_sensors) {
   sensors.clear();
   for (auto &sensor : temp_sensors.items()) {
     std::string key = sensor.key();
+    std::string sensor_name = key;
     bool controllable = sensor.value()["controllable"].template get<bool>();
 
     lv_color_t color_code = lv_palette_main(LV_PALETTE_ORANGE);
     if (!sensor.value()["color"].is_number()) {
       std::string color = sensor.value()["color"].template get<std::string>();
       if (color == "red") {
-	color_code = lv_palette_main(LV_PALETTE_RED);
+        color_code = lv_palette_main(LV_PALETTE_RED);
       } else if (color == "purple") {
-	color_code = lv_palette_main(LV_PALETTE_PURPLE);
+        color_code = lv_palette_main(LV_PALETTE_PURPLE);
       } else if (color == "blue") {
-	color_code = lv_palette_main(LV_PALETTE_BLUE);	
+        color_code = lv_palette_main(LV_PALETTE_BLUE);
       }
     } else {
       color_code = lv_palette_main((lv_palette_t)sensor.value()["color"].template get<int>());
     }
 
     std::string display_name = sensor.value()["display_name"].template get<std::string>();
+
+    SensorType type = SensorType::Heater;
+    auto space_idx = key.find(' ');
+    if (space_idx != std::string::npos) {
+      std::string sensor_type = key.substr(0, space_idx);
+      sensor_name = key.substr(space_idx + 1);
+      if (sensor_type == "temperature_fan") {
+        type = SensorType::TempFan;
+      } else if (sensor_type == "temperature_sensor") {
+        type = SensorType::Sensor;
+      }
+    }
 
     const void* sensor_img = &heater;
     if (key == "extruder") {
@@ -265,9 +278,9 @@ void MainPanel::create_sensors(json &temp_sensors) {
     lv_chart_series_t *temp_series =
       lv_chart_add_series(temp_chart, color_code, LV_CHART_AXIS_PRIMARY_Y);
 
-    sensors.insert({key, std::make_shared<SensorContainer>(ws, temp_cont, sensor_img, 150,
-			   display_name.c_str(), color_code, controllable, false, numpad, key,
-        		   temp_chart, temp_series)});
+    sensors.insert({ key, std::make_shared<SensorContainer>(ws, temp_cont, sensor_img, 150,
+      display_name.c_str(), color_code, controllable, false, numpad, sensor_name,
+      temp_chart, temp_series, type) });
   }
 }
 

--- a/src/print_panel.cpp
+++ b/src/print_panel.cpp
@@ -167,6 +167,10 @@ void PrintPanel::populate_files(json &j) {
 }
 
 void PrintPanel::consume(json &j) {
+  if (j["method"] == "notify_filelist_changed") {
+    subscribe();
+    return;
+  }
   json &pstat_state = j["/params/0/print_stats/state"_json_pointer];
   if (pstat_state.is_null()) {
     return;

--- a/src/print_panel.cpp
+++ b/src/print_panel.cpp
@@ -49,14 +49,15 @@ PrintPanel::PrintPanel(KWebSocketClient &websocket, std::mutex &lock, PrintStatu
   lv_obj_set_style_pad_all(files_cont, 0, 0);
 
   // left side cont
-  lv_obj_set_size(left_cont, LV_PCT(50), LV_PCT(100));
+  lv_obj_set_height(left_cont, LV_PCT(100));
   lv_obj_clear_flag(left_cont, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_flex_flow(left_cont, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_grow(left_cont, 1);
   lv_obj_set_style_pad_all(left_cont, 0, 0);
 
   // file view buttons
   lv_obj_t * label = NULL;
-  
+
   label = lv_label_create(refresh_btn);
   lv_label_set_text(label, LV_SYMBOL_REFRESH " Reload");
   lv_obj_center(label);
@@ -72,13 +73,17 @@ PrintPanel::PrintPanel(KWebSocketClient &websocket, std::mutex &lock, PrintStatu
   lv_obj_add_event_cb(refresh_btn, &PrintPanel::_handle_btns, LV_EVENT_CLICKED, this);
   lv_obj_add_event_cb(modified_sort_btn, &PrintPanel::_handle_btns, LV_EVENT_CLICKED, this);
   lv_obj_add_event_cb(az_sort_btn, &PrintPanel::_handle_btns, LV_EVENT_CLICKED, this);
-  
+
+  lv_obj_set_style_pad_hor(refresh_btn, 19, 0);
+  lv_obj_set_style_pad_hor(modified_sort_btn, 19, 0);
+  lv_obj_set_style_pad_hor(az_sort_btn, 19, 0);
+
   lv_obj_set_size(file_table_btns, LV_PCT(100), LV_SIZE_CONTENT);
-  lv_obj_set_style_pad_all(file_table_btns, 2, 0);
+  lv_obj_set_style_pad_all(file_table_btns, 0, 0);
 
   lv_obj_clear_flag(file_table_btns, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_flex_flow(file_table_btns, LV_FLEX_FLOW_ROW);
-  lv_obj_set_flex_align(file_table_btns, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_END);
+  lv_obj_set_flex_align(file_table_btns, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
 
   lv_obj_set_size(file_table, LV_PCT(100), LV_PCT(100));
   lv_table_set_col_width(file_table, 0, LV_PCT(100));
@@ -86,24 +91,26 @@ PrintPanel::PrintPanel(KWebSocketClient &websocket, std::mutex &lock, PrintStatu
   lv_obj_add_event_cb(file_table, &PrintPanel::_handle_callback, LV_EVENT_ALL, this);
   lv_obj_set_scroll_dir(file_table, LV_DIR_TOP | LV_DIR_BOTTOM);
 
-  lv_obj_set_size(file_view, LV_PCT(50), LV_PCT(100));
+  lv_obj_set_height(file_view, LV_PCT(100));
   lv_obj_clear_flag(file_view, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_flex_grow(file_view, 1);
 
-  static lv_coord_t grid_main_row_dsc[] = {LV_GRID_FR(8), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
+  static lv_coord_t grid_main_row_dsc[] = {LV_GRID_FR(3), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
   static lv_coord_t grid_main_col_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
   lv_obj_set_grid_dsc_array(file_view, grid_main_col_dsc, grid_main_row_dsc);
-  lv_obj_set_grid_cell(file_panel.get_container(), LV_GRID_ALIGN_CENTER, 0, 3, LV_GRID_ALIGN_CENTER, 0, 1);
+  lv_obj_set_grid_cell(file_panel.get_container(), LV_GRID_ALIGN_STRETCH, 0, 3, LV_GRID_ALIGN_STRETCH, 0, 1);
+  lv_obj_set_style_pad_all(file_panel.get_container(), 0, 0);
 
-  lv_obj_set_grid_cell(status_btn.get_container(), LV_GRID_ALIGN_CENTER, 0, 1, LV_GRID_ALIGN_END, 1, 1);  
-  lv_obj_set_grid_cell(print_btn.get_container(), LV_GRID_ALIGN_CENTER, 1, 1, LV_GRID_ALIGN_END, 1, 1);
-  lv_obj_set_grid_cell(back_btn.get_container(), LV_GRID_ALIGN_CENTER, 2, 1, LV_GRID_ALIGN_END, 1, 1);
+  lv_obj_set_grid_cell(status_btn.get_container(), LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(print_btn.get_container(), LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(back_btn.get_container(), LV_GRID_ALIGN_STRETCH, 2, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
 
   lv_obj_move_foreground(back_btn.get_container());
   lv_obj_move_foreground(print_btn.get_container());
-  lv_obj_move_foreground(status_btn.get_container());      
+  lv_obj_move_foreground(status_btn.get_container());
 
   // prompt
-  lv_obj_add_flag(prompt_cont, LV_OBJ_FLAG_HIDDEN);  
+  lv_obj_add_flag(prompt_cont, LV_OBJ_FLAG_HIDDEN);
   lv_obj_set_size(prompt_cont, LV_PCT(100), LV_PCT(100));
   lv_obj_clear_flag(prompt_cont, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_style_bg_opa(prompt_cont, LV_OPA_70, 0);
@@ -111,7 +118,7 @@ PrintPanel::PrintPanel(KWebSocketClient &websocket, std::mutex &lock, PrintStatu
   lv_obj_set_size(msgbox, LV_PCT(60), LV_PCT(30));
   lv_obj_set_style_border_width(msgbox, 2, 0);
   lv_obj_set_style_bg_color(msgbox, lv_palette_darken(LV_PALETTE_GREY, 1), 0);
-  
+
   lv_obj_align(msgbox, LV_ALIGN_CENTER, 0, 0);
 
   lv_obj_add_event_cb(job_btn, &PrintPanel::_handle_btns, LV_EVENT_CLICKED, this);
@@ -122,7 +129,7 @@ PrintPanel::PrintPanel(KWebSocketClient &websocket, std::mutex &lock, PrintStatu
 
   lv_obj_add_event_cb(queue_btn, &PrintPanel::_handle_btns, LV_EVENT_CLICKED, this);
   lv_obj_align(queue_btn, LV_ALIGN_BOTTOM_LEFT, 0, 0);
-  
+
   label = lv_label_create(job_btn);
   lv_label_set_text(label, "View Job");
   lv_obj_center(label);
@@ -159,12 +166,12 @@ void PrintPanel::populate_files(json &j) {
   show_dir(cur_dir, SORTED_BY_MODIFIED);
 }
 
-void PrintPanel::consume(json &j) {  
+void PrintPanel::consume(json &j) {
   json &pstat_state = j["/params/0/print_stats/state"_json_pointer];
   if (pstat_state.is_null()) {
     return;
   }
-  
+
   std::lock_guard<std::mutex> lock(lv_lock);
   if(pstat_state.template get<std::string>() != "printing"
      && pstat_state.template get<std::string>() != "paused") {
@@ -199,7 +206,7 @@ void PrintPanel::foreground() {
     ->get_data("/printer_state/print_stats/state"_json_pointer);
   spdlog::debug("print panel print stats {}",
 		pstat_state.is_null() ? "nil" : pstat_state.template get<std::string>());
-    
+
   if (!pstat_state.is_null()
       && pstat_state.template get<std::string>() != "printing"
       && pstat_state.template get<std::string>() != "paused") {
@@ -207,8 +214,9 @@ void PrintPanel::foreground() {
   } else {
     status_btn.enable();
   }
-  
+
   lv_obj_move_foreground(files_cont);
+  subscribe();
 }
 
 void PrintPanel::handle_callback(lv_event_t *e) {
@@ -226,7 +234,7 @@ void PrintPanel::handle_callback(lv_event_t *e) {
     }
 
     str_fn = lv_table_get_cell_value(file_table, row, col);
-    
+
     const char *filename = str_fn+5; // +5 skips the LV_SYMBOL and spaces
     if (std::memcmp(LV_SYMBOL_DIRECTORY, str_fn, 3) == 0) {
       if ((strcmp(filename, "..") == 0)) {
@@ -278,7 +286,7 @@ void PrintPanel::show_dir(Tree *dir, uint32_t sort_type) {
 	return reversed ? x.name > y.name : y.name > x.name;
       });
   }
-      
+
   sorted_by = (sorted_by ^ sort_type) & sort_type;
   for (const auto &c : sorted_files) {
     if (c.is_leaf()) {
@@ -320,7 +328,7 @@ void PrintPanel::show_file_detail(Tree *f) {
 }
 
 void PrintPanel::handle_metadata(Tree *f, json &j) {
-  spdlog::trace("handling metadata callback");  
+  spdlog::trace("handling metadata callback");
   if (f->is_leaf()) {
     if (j.contains("result")) {
       std::lock_guard<std::mutex> lock(lv_lock);
@@ -334,7 +342,7 @@ void PrintPanel::handle_back_btn(lv_event_t *event) {
   lv_obj_t *btn = lv_event_get_current_target(event);
   if (btn == back_btn.get_container()) {
     lv_obj_move_background(files_cont);
-    print_status.background();    
+    print_status.background();
   }
 }
 
@@ -346,12 +354,12 @@ void PrintPanel::handle_print_callback(lv_event_t *event) {
       ->get_data("/printer_state/print_stats/state"_json_pointer);
     spdlog::debug("print panel print stats {}",
 		  pstat_state.is_null() ? "nil" : pstat_state.template get<std::string>());
-    
+
     if (!pstat_state.is_null()
 	&& pstat_state.template get<std::string>() != "printing"
 	&& pstat_state.template get<std::string>() != "paused") {
       spdlog::debug("printer ready to print. print file {}", cur_file->full_path);
-	
+
       // ws.send_jsonrpc("printer.gcode.script",
       // 		    json::parse(R"({"script":"PRINT_PREPARE_CLEAR"})"));
 
@@ -397,7 +405,7 @@ void PrintPanel::handle_btns(lv_event_t *event) {
 
     if (btn == refresh_btn) {
       subscribe();
-      
+
     } else if (btn == modified_sort_btn) {
       show_dir(cur_dir, SORTED_BY_MODIFIED);
 

--- a/src/print_panel.cpp
+++ b/src/print_panel.cpp
@@ -56,7 +56,7 @@ PrintPanel::PrintPanel(KWebSocketClient &websocket, std::mutex &lock, PrintStatu
   lv_obj_set_style_pad_all(left_cont, 0, 0);
 
   // file view buttons
-  lv_obj_t * label = NULL;
+  lv_obj_t *label = NULL;
 
   label = lv_label_create(refresh_btn);
   lv_label_set_text(label, LV_SYMBOL_REFRESH " Reload");
@@ -173,8 +173,8 @@ void PrintPanel::consume(json &j) {
   }
 
   std::lock_guard<std::mutex> lock(lv_lock);
-  if(pstat_state.template get<std::string>() != "printing"
-     && pstat_state.template get<std::string>() != "paused") {
+  if (pstat_state.template get<std::string>() != "printing"
+    && pstat_state.template get<std::string>() != "paused") {
     status_btn.disable();
   } else {
     status_btn.enable();
@@ -198,18 +198,18 @@ void PrintPanel::subscribe() {
     // need to simply this using the directory endpoint
     cur_dir = dir;
     this->populate_files(d);
-  });
+    });
 }
 
 void PrintPanel::foreground() {
   json &pstat_state = State::get_instance()
     ->get_data("/printer_state/print_stats/state"_json_pointer);
   spdlog::debug("print panel print stats {}",
-		pstat_state.is_null() ? "nil" : pstat_state.template get<std::string>());
+    pstat_state.is_null() ? "nil" : pstat_state.template get<std::string>());
 
   if (!pstat_state.is_null()
-      && pstat_state.template get<std::string>() != "printing"
-      && pstat_state.template get<std::string>() != "paused") {
+    && pstat_state.template get<std::string>() != "printing"
+    && pstat_state.template get<std::string>() != "paused") {
     status_btn.disable();
   } else {
     status_btn.enable();
@@ -222,8 +222,8 @@ void PrintPanel::foreground() {
 void PrintPanel::handle_callback(lv_event_t *e) {
   lv_event_code_t code = lv_event_get_code(e);
 
-  if(code == LV_EVENT_VALUE_CHANGED) {
-    const char * str_fn = NULL;
+  if (code == LV_EVENT_VALUE_CHANGED) {
+    const char *str_fn = NULL;
     uint16_t row;
     uint16_t col;
 
@@ -235,25 +235,24 @@ void PrintPanel::handle_callback(lv_event_t *e) {
 
     str_fn = lv_table_get_cell_value(file_table, row, col);
 
-    const char *filename = str_fn+5; // +5 skips the LV_SYMBOL and spaces
+    const char *filename = str_fn + 5; // +5 skips the LV_SYMBOL and spaces
     if (std::memcmp(LV_SYMBOL_DIRECTORY, str_fn, 3) == 0) {
       if ((strcmp(filename, "..") == 0)) {
-	if (cur_dir->parent != cur_dir) {
-	  cur_dir = cur_dir->parent;
-	  show_dir(cur_dir, sorted_by);
-	}
+        if (cur_dir->parent != cur_dir) {
+          cur_dir = cur_dir->parent;
+          show_dir(cur_dir, sorted_by);
+        }
       } else {
-	Tree *dir = cur_dir->get_child(filename);
-	if (dir != NULL) {
-	  cur_dir = dir;
-	  show_dir(cur_dir, sorted_by);
-	}
+        Tree *dir = cur_dir->get_child(filename);
+        if (dir != NULL) {
+          cur_dir = dir;
+          show_dir(cur_dir, sorted_by);
+        }
       }
-    }
-    else {
+    } else {
       if (cur_file != cur_dir->get_child(filename)) {
-	cur_file = cur_dir->get_child(filename);
-	show_file_detail(cur_file);
+        cur_file = cur_dir->get_child(filename);
+        show_file_detail(cur_file);
       }
     }
   }
@@ -267,23 +266,23 @@ void PrintPanel::show_dir(Tree *dir, uint32_t sort_type) {
   std::vector<Tree> sorted_files;
   if (sort_type == SORTED_BY_MODIFIED) {
     KUtils::sort_map_values<std::string, Tree>(dir->children, sorted_files, [reversed](Tree &x, Tree &y) {
-	if (x.is_leaf() && !y.is_leaf()) {
-	  return false;
-	} else if (!x.is_leaf() && y.is_leaf()) {
-	  return true;
-	}
+      if (x.is_leaf() && !y.is_leaf()) {
+        return false;
+      } else if (!x.is_leaf() && y.is_leaf()) {
+        return true;
+      }
 
-	return reversed ? x.date_modified > y.date_modified : y.date_modified > x.date_modified;
+      return reversed ? x.date_modified > y.date_modified : y.date_modified > x.date_modified;
       });
   } else {
     KUtils::sort_map_values<std::string, Tree>(dir->children, sorted_files, [reversed](Tree &x, Tree &y) {
-	if (x.is_leaf() && !y.is_leaf()) {
-	  return false;
-	} else if (!x.is_leaf() && y.is_leaf()) {
-	  return true;
-	}
+      if (x.is_leaf() && !y.is_leaf()) {
+        return false;
+      } else if (!x.is_leaf() && y.is_leaf()) {
+        return true;
+      }
 
-	return reversed ? x.name > y.name : y.name > x.name;
+      return reversed ? x.name > y.name : y.name > x.name;
       });
   }
 
@@ -305,8 +304,8 @@ void PrintPanel::show_dir(Tree *dir, uint32_t sort_type) {
     if (c.is_leaf()) {
       const auto &selected = dir->children.find(c.name);
       if (selected != dir->children.cend()) {
-	cur_file = &selected->second;
-	show_file_detail(cur_file);
+        cur_file = &selected->second;
+        show_file_detail(cur_file);
       }
       break;
     }
@@ -321,8 +320,8 @@ void PrintPanel::show_file_detail(Tree *f) {
     } else {
       spdlog::trace("getting metadata for {}", f->name);
       ws.send_jsonrpc("server.files.metadata",
-		      json::parse(R"({"filename":")" + f->full_path + R"("})"),
-		      [f, this](json &d) { this->handle_metadata(f, d); });
+        json::parse(R"({"filename":")" + f->full_path + R"("})"),
+        [f, this](json &d) { this->handle_metadata(f, d); });
     }
   }
 }
@@ -353,11 +352,11 @@ void PrintPanel::handle_print_callback(lv_event_t *event) {
     json &pstat_state = State::get_instance()
       ->get_data("/printer_state/print_stats/state"_json_pointer);
     spdlog::debug("print panel print stats {}",
-		  pstat_state.is_null() ? "nil" : pstat_state.template get<std::string>());
+      pstat_state.is_null() ? "nil" : pstat_state.template get<std::string>());
 
     if (!pstat_state.is_null()
-	&& pstat_state.template get<std::string>() != "printing"
-	&& pstat_state.template get<std::string>() != "paused") {
+      && pstat_state.template get<std::string>() != "printing"
+      && pstat_state.template get<std::string>() != "paused") {
       spdlog::debug("printer ready to print. print file {}", cur_file->full_path);
 
       // ws.send_jsonrpc("printer.gcode.script",
@@ -389,17 +388,17 @@ void PrintPanel::handle_btns(lv_event_t *event) {
     if (cur_file != NULL) {
       spdlog::trace("status prompt clicked");
       if (btn == queue_btn) {
-	spdlog::trace("status prompt queue clicked");
+        spdlog::trace("status prompt queue clicked");
       }
 
       if (btn == job_btn) {
-	spdlog::trace("status prompt job clicked");
+        spdlog::trace("status prompt job clicked");
       }
 
       if (btn == cancel_btn) {
-	spdlog::trace("status prompt cancel clicked");
-	lv_obj_move_background(prompt_cont);
-	lv_obj_add_flag(prompt_cont, LV_OBJ_FLAG_HIDDEN);
+        spdlog::trace("status prompt cancel clicked");
+        lv_obj_move_background(prompt_cont);
+        lv_obj_add_flag(prompt_cont, LV_OBJ_FLAG_HIDDEN);
       }
     }
 

--- a/src/print_panel.h
+++ b/src/print_panel.h
@@ -24,7 +24,7 @@ class PrintPanel : public NotifyConsumer {
   void handle_print_callback(lv_event_t *event);
   void handle_status_btn(lv_event_t *event);
   void handle_btns(lv_event_t *event);
-  
+
   static void _handle_callback(lv_event_t *event) {
     PrintPanel *panel = (PrintPanel*)event->user_data;
     panel->handle_callback(event);
@@ -34,7 +34,7 @@ class PrintPanel : public NotifyConsumer {
     PrintPanel *panel = (PrintPanel*)event->user_data;
     panel->handle_back_btn(event);
   };
-  
+
   static void _handle_print_callback(lv_event_t *event) {
     PrintPanel *panel = (PrintPanel*)event->user_data;
     panel->handle_print_callback(event);
@@ -49,12 +49,12 @@ class PrintPanel : public NotifyConsumer {
     PrintPanel *panel = (PrintPanel*)event->user_data;
     panel->handle_btns(event);
   };
-  
-  
+
+
  private:
   void show_dir(Tree *dir, uint32_t sort_type);
   void show_file_detail(Tree *f);
-  
+
   KWebSocketClient &ws;
   lv_obj_t *files_cont;
 
@@ -70,7 +70,7 @@ class PrintPanel : public NotifyConsumer {
   lv_obj_t *refresh_btn;
   lv_obj_t *modified_sort_btn;
   lv_obj_t *az_sort_btn;
-  
+
   lv_obj_t *file_table;
   lv_obj_t *file_view;
   ButtonContainer status_btn;

--- a/src/print_panel.h
+++ b/src/print_panel.h
@@ -10,7 +10,7 @@
 #include "tree.h"
 
 class PrintPanel : public NotifyConsumer {
- public:
+public:
   PrintPanel(KWebSocketClient &ws, std::mutex &lv_lock, PrintStatusPanel &ps);
   ~PrintPanel();
 
@@ -19,39 +19,39 @@ class PrintPanel : public NotifyConsumer {
   void subscribe();
   void foreground();
   void handle_callback(lv_event_t *event);
-  void handle_metadata(Tree *, json & data);
+  void handle_metadata(Tree *, json &data);
   void handle_back_btn(lv_event_t *event);
   void handle_print_callback(lv_event_t *event);
   void handle_status_btn(lv_event_t *event);
   void handle_btns(lv_event_t *event);
 
   static void _handle_callback(lv_event_t *event) {
-    PrintPanel *panel = (PrintPanel*)event->user_data;
+    PrintPanel *panel = (PrintPanel *)event->user_data;
     panel->handle_callback(event);
   };
 
   static void _handle_back_btn(lv_event_t *event) {
-    PrintPanel *panel = (PrintPanel*)event->user_data;
+    PrintPanel *panel = (PrintPanel *)event->user_data;
     panel->handle_back_btn(event);
   };
 
   static void _handle_print_callback(lv_event_t *event) {
-    PrintPanel *panel = (PrintPanel*)event->user_data;
+    PrintPanel *panel = (PrintPanel *)event->user_data;
     panel->handle_print_callback(event);
   };
 
   static void _handle_status_btn(lv_event_t *event) {
-    PrintPanel *panel = (PrintPanel*)event->user_data;
+    PrintPanel *panel = (PrintPanel *)event->user_data;
     panel->handle_status_btn(event);
   };
 
   static void _handle_btns(lv_event_t *event) {
-    PrintPanel *panel = (PrintPanel*)event->user_data;
+    PrintPanel *panel = (PrintPanel *)event->user_data;
     panel->handle_btns(event);
   };
 
 
- private:
+private:
   void show_dir(Tree *dir, uint32_t sort_type);
   void show_file_detail(Tree *f);
 

--- a/src/print_status_panel.cpp
+++ b/src/print_status_panel.cpp
@@ -79,35 +79,36 @@ PrintStatusPanel::PrintStatusPanel(KWebSocketClient &websocket_client,
   lv_obj_set_grid_dsc_array(detail_cont, grid_main_col_dsc_detail, grid_main_row_dsc_detail);
 
   lv_obj_clear_flag(detail_cont, LV_OBJ_FLAG_SCROLLABLE);
-  lv_obj_set_size(detail_cont, LV_PCT(60), LV_PCT(60));
+  lv_obj_set_style_pad_all(detail_cont, 0, 0);
 
   //detail containter row 1
-  lv_obj_set_grid_cell(extruder_temp.get_container(), LV_GRID_ALIGN_START, 0, 1, LV_GRID_ALIGN_START, 0, 1);
-  lv_obj_set_grid_cell(bed_temp.get_container(), LV_GRID_ALIGN_START, 1, 1, LV_GRID_ALIGN_START, 0, 1);
+  lv_obj_set_grid_cell(extruder_temp.get_container(), LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
+  lv_obj_set_grid_cell(bed_temp.get_container(), LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
 
   //detail containter row 2
-  lv_obj_set_grid_cell(print_speed.get_container(), LV_GRID_ALIGN_START, 0, 1, LV_GRID_ALIGN_START, 1, 1);
-  lv_obj_set_grid_cell(z_offset.get_container(), LV_GRID_ALIGN_START, 1, 1, LV_GRID_ALIGN_START, 1, 1);
+  lv_obj_set_grid_cell(print_speed.get_container(), LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(z_offset.get_container(), LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
 
   //detail containter row 3
-  lv_obj_set_grid_cell(flow_rate.get_container(), LV_GRID_ALIGN_START, 0, 1, LV_GRID_ALIGN_START, 2, 1);
-  lv_obj_set_grid_cell(layers.get_container(), LV_GRID_ALIGN_START, 1, 1, LV_GRID_ALIGN_START, 2, 1);
+  lv_obj_set_grid_cell(flow_rate.get_container(), LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 2, 1);
+  lv_obj_set_grid_cell(layers.get_container(), LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH, 2, 1);
 
   //detail containter row 4
-  lv_obj_set_grid_cell(elapsed.get_container(), LV_GRID_ALIGN_START, 0, 1, LV_GRID_ALIGN_START, 3, 1);
-  lv_obj_set_grid_cell(fan0.get_container(), LV_GRID_ALIGN_START, 1, 1, LV_GRID_ALIGN_START, 3, 1);
+  lv_obj_set_grid_cell(elapsed.get_container(), LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 3, 1);
+  lv_obj_set_grid_cell(fan0.get_container(), LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH, 3, 1);
 
   //detail containter row 5
-  lv_obj_set_grid_cell(time_left.get_container(), LV_GRID_ALIGN_START, 0, 1, LV_GRID_ALIGN_START, 4, 1);
+  lv_obj_set_grid_cell(time_left.get_container(), LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 4, 1);
   // lv_obj_set_grid_cell(fan2.get_container(), LV_GRID_ALIGN_START, 1, 1, LV_GRID_ALIGN_START, 4, 1);
 
-  static lv_coord_t grid_main_row_dsc[] = {LV_GRID_FR(2), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
-  static lv_coord_t grid_main_col_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
+  static lv_coord_t grid_main_row_dsc[] = {LV_GRID_FR(1), LV_GRID_CONTENT, LV_GRID_TEMPLATE_LAST};
+  static lv_coord_t grid_main_col_dsc[] = {LV_GRID_FR(4), LV_GRID_FR(5), LV_GRID_TEMPLATE_LAST};
 
   lv_obj_set_grid_dsc_array(status_cont, grid_main_col_dsc, grid_main_row_dsc);
 
-  lv_obj_set_size(buttons_cont, LV_PCT(100), LV_PCT(40));
+  lv_obj_set_size(buttons_cont, LV_PCT(100), LV_SIZE_CONTENT);
   lv_obj_clear_flag(buttons_cont, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_style_pad_all(buttons_cont, 0, 0);
   lv_obj_set_flex_flow(buttons_cont, LV_FLEX_FLOW_ROW);
   lv_obj_set_flex_align(buttons_cont, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
 
@@ -119,29 +120,26 @@ PrintStatusPanel::PrintStatusPanel(KWebSocketClient &websocket_client,
   lv_obj_set_flex_grow(back_btn.get_container(), 1);
 
   lv_obj_set_style_pad_all(pbar_cont, 0, 0);
-  lv_obj_set_size(pbar_cont, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
+  lv_obj_set_size(pbar_cont, LV_PCT(100), LV_SIZE_CONTENT);
   // lv_obj_set_style_border_width(pbar_cont, 2, 0);
   // lv_obj_set_style_border_width(thumbnail_cont, 2, 0);
 
-  auto bar_width = (double)lv_disp_get_physical_hor_res(NULL) * 0.35;
   auto hscale = (double)lv_disp_get_physical_ver_res(NULL) / 480.0;
 
-  lv_obj_set_size(progress_bar, bar_width, 20 * hscale);
+  lv_obj_set_size(progress_bar, LV_PCT(100), 20 * hscale);
   lv_bar_set_value(progress_bar, 0, LV_ANIM_OFF);
-  lv_obj_center(progress_bar);
 
   lv_label_set_text(progress_label, "0%");
   lv_obj_center(progress_label);
 
   lv_obj_set_flex_flow(thumbnail_cont, LV_FLEX_FLOW_COLUMN);
-  lv_obj_set_flex_align(thumbnail_cont, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_START);
+  lv_obj_set_flex_align(thumbnail_cont, LV_FLEX_ALIGN_END, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
   lv_obj_set_size(thumbnail_cont, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
   lv_obj_set_style_pad_all(thumbnail_cont, 0, 0);
-  lv_obj_set_style_pad_row(thumbnail_cont, 20, 0);
 
   // row 1
-  lv_obj_set_grid_cell(thumbnail_cont, LV_GRID_ALIGN_CENTER, 0, 1, LV_GRID_ALIGN_CENTER, 0, 1);
-  lv_obj_set_grid_cell(detail_cont, LV_GRID_ALIGN_CENTER, 1, 1, LV_GRID_ALIGN_CENTER, 0, 1);
+  lv_obj_set_grid_cell(thumbnail_cont, LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
+  lv_obj_set_grid_cell(detail_cont, LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
 
   //row 2
   lv_obj_set_grid_cell(buttons_cont, LV_GRID_ALIGN_STRETCH, 0, 2, LV_GRID_ALIGN_STRETCH, 1, 1);
@@ -296,10 +294,20 @@ void PrintStatusPanel::handle_metadata(const std::string &gcode_file, json &j) {
     std::lock_guard<std::mutex> lock(lv_lock);
     const std::string img_path = "A:" + fullpath;
 
-    auto screen_width = lv_disp_get_physical_hor_res(NULL);
-    uint32_t normalized_thumb_scale = ((0.34 * (double)screen_width) / (double)thumb_detail.second.first) * 256;
     lv_img_set_src(thumbnail, img_path.c_str());
-    lv_img_set_zoom(thumbnail, normalized_thumb_scale);
+    auto thumb_w = thumb_detail.second.first;
+    auto thumb_h = thumb_detail.second.second;
+
+    auto available_w = lv_obj_get_width(thumbnail_cont);
+    auto available_h = lv_obj_get_height(thumbnail_cont) - lv_obj_get_height(pbar_cont) - lv_obj_get_style_pad_row(thumbnail_cont, LV_PART_MAIN);
+
+    double scale_x = (double)available_w / (double)thumb_w;
+    double scale_y = (double)available_h / (double)thumb_h;
+    double scale = std::min(scale_x, scale_y);
+
+    uint32_t lv_zoom = static_cast<uint32_t>(scale * 256.0);
+    lv_img_set_pivot(thumbnail, thumb_w / 2, thumb_h);
+    lv_img_set_zoom(thumbnail, lv_zoom);
     mini_print_status.update_img(img_path, thumb_detail.second.first);
   }
 }

--- a/src/print_status_panel.cpp
+++ b/src/print_status_panel.cpp
@@ -70,7 +70,7 @@ PrintStatusPanel::PrintStatusPanel(KWebSocketClient &websocket_client,
   , heater_bed_target(-1)
 {
   lv_obj_move_background(status_cont);
-  lv_obj_clear_flag(status_cont, LV_OBJ_FLAG_SCROLLABLE);  
+  lv_obj_clear_flag(status_cont, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_size(status_cont, LV_PCT(100), LV_PCT(100));
 
   static lv_coord_t grid_main_row_dsc_detail[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1),
@@ -78,16 +78,16 @@ PrintStatusPanel::PrintStatusPanel(KWebSocketClient &websocket_client,
   static lv_coord_t grid_main_col_dsc_detail[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
   lv_obj_set_grid_dsc_array(detail_cont, grid_main_col_dsc_detail, grid_main_row_dsc_detail);
 
-  lv_obj_clear_flag(detail_cont, LV_OBJ_FLAG_SCROLLABLE);  
+  lv_obj_clear_flag(detail_cont, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_size(detail_cont, LV_PCT(60), LV_PCT(60));
 
   //detail containter row 1
   lv_obj_set_grid_cell(extruder_temp.get_container(), LV_GRID_ALIGN_START, 0, 1, LV_GRID_ALIGN_START, 0, 1);
-  lv_obj_set_grid_cell(bed_temp.get_container(), LV_GRID_ALIGN_START, 1, 1, LV_GRID_ALIGN_START, 0, 1);  
+  lv_obj_set_grid_cell(bed_temp.get_container(), LV_GRID_ALIGN_START, 1, 1, LV_GRID_ALIGN_START, 0, 1);
 
   //detail containter row 2
   lv_obj_set_grid_cell(print_speed.get_container(), LV_GRID_ALIGN_START, 0, 1, LV_GRID_ALIGN_START, 1, 1);
-  lv_obj_set_grid_cell(z_offset.get_container(), LV_GRID_ALIGN_START, 1, 1, LV_GRID_ALIGN_START, 1, 1);  
+  lv_obj_set_grid_cell(z_offset.get_container(), LV_GRID_ALIGN_START, 1, 1, LV_GRID_ALIGN_START, 1, 1);
 
   //detail containter row 3
   lv_obj_set_grid_cell(flow_rate.get_container(), LV_GRID_ALIGN_START, 0, 1, LV_GRID_ALIGN_START, 2, 1);
@@ -99,17 +99,24 @@ PrintStatusPanel::PrintStatusPanel(KWebSocketClient &websocket_client,
 
   //detail containter row 5
   lv_obj_set_grid_cell(time_left.get_container(), LV_GRID_ALIGN_START, 0, 1, LV_GRID_ALIGN_START, 4, 1);
-  // lv_obj_set_grid_cell(fan2.get_container(), LV_GRID_ALIGN_START, 1, 1, LV_GRID_ALIGN_START, 4, 1);  
-  
+  // lv_obj_set_grid_cell(fan2.get_container(), LV_GRID_ALIGN_START, 1, 1, LV_GRID_ALIGN_START, 4, 1);
+
   static lv_coord_t grid_main_row_dsc[] = {LV_GRID_FR(2), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
   static lv_coord_t grid_main_col_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
 
   lv_obj_set_grid_dsc_array(status_cont, grid_main_col_dsc, grid_main_row_dsc);
 
   lv_obj_set_size(buttons_cont, LV_PCT(100), LV_PCT(40));
-  lv_obj_clear_flag(buttons_cont, LV_OBJ_FLAG_SCROLLABLE);  
+  lv_obj_clear_flag(buttons_cont, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_flex_flow(buttons_cont, LV_FLEX_FLOW_ROW);
-  lv_obj_set_flex_align(buttons_cont, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+  lv_obj_set_flex_align(buttons_cont, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+  lv_obj_set_flex_grow(finetune_btn.get_container(), 1);
+  lv_obj_set_flex_grow(pause_btn.get_container(), 1);
+  lv_obj_set_flex_grow(resume_btn.get_container(), 1);
+  lv_obj_set_flex_grow(cancel_btn.get_container(), 1);
+  lv_obj_set_flex_grow(emergency_btn.get_container(), 1);
+  lv_obj_set_flex_grow(back_btn.get_container(), 1);
 
   lv_obj_set_style_pad_all(pbar_cont, 0, 0);
   lv_obj_set_size(pbar_cont, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
@@ -134,11 +141,11 @@ PrintStatusPanel::PrintStatusPanel(KWebSocketClient &websocket_client,
 
   // row 1
   lv_obj_set_grid_cell(thumbnail_cont, LV_GRID_ALIGN_CENTER, 0, 1, LV_GRID_ALIGN_CENTER, 0, 1);
-  lv_obj_set_grid_cell(detail_cont, LV_GRID_ALIGN_CENTER, 1, 1, LV_GRID_ALIGN_CENTER, 0, 1);  
+  lv_obj_set_grid_cell(detail_cont, LV_GRID_ALIGN_CENTER, 1, 1, LV_GRID_ALIGN_CENTER, 0, 1);
 
   //row 2
-  lv_obj_set_grid_cell(buttons_cont, LV_GRID_ALIGN_CENTER, 0, 2, LV_GRID_ALIGN_CENTER, 1, 1);
-  
+  lv_obj_set_grid_cell(buttons_cont, LV_GRID_ALIGN_STRETCH, 0, 2, LV_GRID_ALIGN_STRETCH, 1, 1);
+
   ws.register_notify_update(this);
 }
 
@@ -190,7 +197,7 @@ void PrintStatusPanel::init(json &fans) {
     std::string fan_name = f.key();
 
     auto fan_value = State::get_instance()
-      ->get_data(json::json_pointer(fmt::format("/printer_state/{}/value", fan_name)));    
+      ->get_data(json::json_pointer(fmt::format("/printer_state/{}/value", fan_name)));
     if (!fan_value.is_null()) {
       int v = static_cast<int>(fan_value.template get<double>() * 100);
       fan_speeds.insert({fan_name, v});
@@ -221,7 +228,7 @@ void PrintStatusPanel::init(json &fans) {
   } else {
     mini_print_status.show();
   }
-  
+
 }
 
 void PrintStatusPanel::populate() {
@@ -267,7 +274,7 @@ void PrintStatusPanel::handle_metadata(const std::string &gcode_file, json &j) {
   auto eta = j["/result/estimated_time"_json_pointer];
   if (!eta.is_null()) {
     estimated_time_s = static_cast<uint32_t>(eta.template get<float>());
-    spdlog::trace("updated eta {}", estimated_time_s);        
+    spdlog::trace("updated eta {}", estimated_time_s);
 
     json &v = State::get_instance()->get_data("/printer_state/print_stats/print_duration"_json_pointer);
     if (!v.is_null()) {
@@ -290,10 +297,10 @@ void PrintStatusPanel::handle_metadata(const std::string &gcode_file, json &j) {
     const std::string img_path = "A:" + fullpath;
 
     auto screen_width = lv_disp_get_physical_hor_res(NULL);
-    uint32_t normalized_thumb_scale = ((0.34 * (double)screen_width) / (double)thumb_detail.second) * 256;
+    uint32_t normalized_thumb_scale = ((0.34 * (double)screen_width) / (double)thumb_detail.second.first) * 256;
     lv_img_set_src(thumbnail, img_path.c_str());
     lv_img_set_zoom(thumbnail, normalized_thumb_scale);
-    mini_print_status.update_img(img_path, thumb_detail.second);
+    mini_print_status.update_img(img_path, thumb_detail.second.first);
   }
 }
 
@@ -329,8 +336,8 @@ void PrintStatusPanel::consume(json &j) {
   v = j["/params/0/heater_bed/target"_json_pointer];
   if (!v.is_null()) {
     heater_bed_target = v.template get<int>();
-  }  
-  
+  }
+
   v = j["/params/0/extruder/temperature"_json_pointer];
   if (!v.is_null()) {
     if (extruder_target > 0) {
@@ -355,7 +362,7 @@ void PrintStatusPanel::consume(json &j) {
     int s = static_cast<int>(speed.template get<double>());
     print_speed.update_label((std::to_string(s) + " mm/s").c_str());
   }
-  
+
   // zoffset
   v = j["/params/0/gcode_move/homing_origin/2"_json_pointer];
   if (!v.is_null()) {
@@ -411,13 +418,13 @@ void PrintStatusPanel::consume(json &j) {
     if (is_paused) {
       resume_btn.enable();
       lv_obj_clear_flag(resume_btn.get_container(), LV_OBJ_FLAG_HIDDEN);
-      
+
       pause_btn.disable();
       lv_obj_add_flag(pause_btn.get_container(), LV_OBJ_FLAG_HIDDEN);
 
     } else {
       pause_btn.enable();
-      lv_obj_clear_flag(pause_btn.get_container(), LV_OBJ_FLAG_HIDDEN);      
+      lv_obj_clear_flag(pause_btn.get_container(), LV_OBJ_FLAG_HIDDEN);
 
       resume_btn.disable();
       lv_obj_add_flag(resume_btn.get_container(), LV_OBJ_FLAG_HIDDEN);

--- a/src/printertune_panel.cpp
+++ b/src/printertune_panel.cpp
@@ -54,9 +54,9 @@ PrinterTunePanel::PrinterTunePanel(KWebSocketClient &c, std::mutex &l, lv_obj_t 
 
   tmc_tune_btn.disable();
 
-  static lv_coord_t grid_main_row_dsc[] = { LV_GRID_FR(1), LV_GRID_FR(5), LV_GRID_FR(5), LV_GRID_FR(1),
-    LV_GRID_TEMPLATE_LAST };
-  static lv_coord_t grid_main_col_dsc[] = { LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1),
+  static lv_coord_t grid_main_row_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(5), LV_GRID_FR(5), LV_GRID_FR(1),
+    LV_GRID_TEMPLATE_LAST};
+  static lv_coord_t grid_main_col_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1),
       LV_GRID_TEMPLATE_LAST};
 
   lv_obj_set_grid_dsc_array(cont, grid_main_col_dsc, grid_main_row_dsc);
@@ -86,11 +86,11 @@ lv_obj_t *PrinterTunePanel::get_container() {
   return cont;
 }
 
-BedMeshPanel& PrinterTunePanel::get_bedmesh_panel() {
+BedMeshPanel &PrinterTunePanel::get_bedmesh_panel() {
   return bedmesh_panel;
 }
 
-PowerPanel& PrinterTunePanel::get_power_panel() {
+PowerPanel &PrinterTunePanel::get_power_panel() {
   return power_panel;
 }
 

--- a/src/printertune_panel.cpp
+++ b/src/printertune_panel.cpp
@@ -54,23 +54,24 @@ PrinterTunePanel::PrinterTunePanel(KWebSocketClient &c, std::mutex &l, lv_obj_t 
 
   tmc_tune_btn.disable();
 
-  static lv_coord_t grid_main_row_dsc[] = {LV_GRID_FR(2), LV_GRID_FR(5), LV_GRID_FR(5), LV_GRID_TEMPLATE_LAST};
-  static lv_coord_t grid_main_col_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1),
+  static lv_coord_t grid_main_row_dsc[] = { LV_GRID_FR(1), LV_GRID_FR(5), LV_GRID_FR(5), LV_GRID_FR(1),
+    LV_GRID_TEMPLATE_LAST };
+  static lv_coord_t grid_main_col_dsc[] = { LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1),
       LV_GRID_TEMPLATE_LAST};
 
   lv_obj_set_grid_dsc_array(cont, grid_main_col_dsc, grid_main_row_dsc);
 
   // row 1
-  lv_obj_set_grid_cell(bedmesh_btn.get_container(), LV_GRID_ALIGN_CENTER, 0, 1, LV_GRID_ALIGN_START, 1, 1);
-  lv_obj_set_grid_cell(finetune_btn.get_container(), LV_GRID_ALIGN_CENTER, 1, 1, LV_GRID_ALIGN_START, 1, 1);
-  lv_obj_set_grid_cell(inputshaper_btn.get_container(), LV_GRID_ALIGN_CENTER, 2, 1, LV_GRID_ALIGN_START, 1, 1);
-  lv_obj_set_grid_cell(belts_calibration_btn.get_container(), LV_GRID_ALIGN_CENTER, 3, 1, LV_GRID_ALIGN_START, 1, 1);
+  lv_obj_set_grid_cell(bedmesh_btn.get_container(), LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(finetune_btn.get_container(), LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(inputshaper_btn.get_container(), LV_GRID_ALIGN_STRETCH, 2, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(belts_calibration_btn.get_container(), LV_GRID_ALIGN_STRETCH, 3, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
 
   // row 2
-  lv_obj_set_grid_cell(limits_btn.get_container(), LV_GRID_ALIGN_CENTER, 0, 1, LV_GRID_ALIGN_START, 2, 1);
-  lv_obj_set_grid_cell(tmc_tune_btn.get_container(), LV_GRID_ALIGN_CENTER, 1, 1, LV_GRID_ALIGN_START, 2, 1);
-  lv_obj_set_grid_cell(tmc_status_btn.get_container(), LV_GRID_ALIGN_CENTER, 2, 1, LV_GRID_ALIGN_START, 2, 1);
-  lv_obj_set_grid_cell(power_devices_btn.get_container(), LV_GRID_ALIGN_CENTER, 3, 1, LV_GRID_ALIGN_START, 2, 1);
+  lv_obj_set_grid_cell(limits_btn.get_container(), LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 2, 1);
+  lv_obj_set_grid_cell(tmc_tune_btn.get_container(), LV_GRID_ALIGN_STRETCH, 3, 1, LV_GRID_ALIGN_STRETCH, 2, 1);
+  lv_obj_set_grid_cell(tmc_status_btn.get_container(), LV_GRID_ALIGN_STRETCH, 2, 1, LV_GRID_ALIGN_STRETCH, 2, 1);
+  lv_obj_set_grid_cell(power_devices_btn.get_container(), LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH, 2, 1);
   // lv_obj_set_grid_cell(restart_firmware_btn.get_container(), LV_GRID_ALIGN_CENTER, 3, 1, LV_GRID_ALIGN_START, 2, 1);
 }
 

--- a/src/prompt_panel.cpp
+++ b/src/prompt_panel.cpp
@@ -3,364 +3,218 @@
 #include "utils.h"
 #include "spdlog/spdlog.h"
 
-// uncomment for helper boxes
-// #define DEBUG_LINES
+// #define DEBUG_BOXES
 
 static lv_style_t style_btn_grey;
 static lv_style_t style_btn_blue;
 static lv_style_t style_btn_red;
 static lv_style_t style_btn_orange;
 static lv_style_t style_btn_dark_grey;
-static lv_style_t button_group_flex_style;
 
-PromptPanel::PromptPanel(KWebSocketClient &websocket_client, std::mutex &lock, lv_obj_t *parent)
-    : NotifyConsumer(lock)
-    , ws(websocket_client)
-    , prompt_cont(lv_obj_create(lv_scr_act()))
-    , flex(lv_obj_create(prompt_cont))
-    , header(lv_label_create(prompt_cont))
-    , footer_cont(lv_obj_create(prompt_cont))
-//  , back_btn(promptpanel_cont, &back, "Back", &PromptPanel::_handle_callback, this)
+PromptPanel::PromptPanel(KWebSocketClient &websocket_client,
+  std::mutex &lock,
+  lv_obj_t *parent)
+  : NotifyConsumer(lock)
+  , ws(websocket_client)
+  , prompt_cont(lv_obj_create(lv_scr_act()))
+  , header(lv_label_create(prompt_cont))
+  , body_cont(lv_obj_create(prompt_cont))
+  , body(lv_label_create(body_cont))
+  , button_cont(lv_obj_create(body_cont))
+  , footer_cont(lv_obj_create(prompt_cont))
 {
-    lv_obj_set_style_pad_all(prompt_cont, 0, 0);
-    
-    // lv_obj_clear_flag(promptpanel_cont, LV_OBJ_FLAG_SCROLLABLE);
+  // PROMPT PANEL
+  lv_obj_center(prompt_cont);
+  lv_obj_set_size(prompt_cont, lv_pct(60), lv_pct(90));
+  lv_obj_set_style_border_width(prompt_cont, 2, 0);
+  lv_obj_set_style_border_color(prompt_cont, lv_palette_main(LV_PALETTE_GREY), 0);
+  lv_obj_set_style_radius(prompt_cont, 16, 0);
+  lv_obj_set_style_pad_all(prompt_cont, 8, 0);
+  lv_obj_set_style_pad_row(prompt_cont, 0, 0);
 
-    static lv_coord_t grid_main_row_dsc_detail[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
-    // header, flex, buttons
-    static lv_coord_t grid_main_col_dsc_detail[] = {LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST}; 
-    // single column
-
-    lv_obj_center(prompt_cont);
-    lv_obj_set_style_pad_all(prompt_cont, 5, 0);
-    lv_obj_set_style_radius(prompt_cont, 5, LV_PART_MAIN);
-    lv_obj_set_style_border_width(prompt_cont, 2, LV_PART_MAIN | LV_STATE_DEFAULT);
-    lv_obj_set_style_border_color(prompt_cont, lv_palette_main(LV_PALETTE_GREY), LV_PART_MAIN | LV_STATE_DEFAULT);
-    lv_obj_set_style_max_height(prompt_cont, lv_pct(80), 0);
-    lv_obj_set_style_max_width(prompt_cont, lv_pct(75), 0);
-    lv_obj_set_style_min_height(prompt_cont, lv_pct(50), 0);
-    lv_obj_set_style_min_width(prompt_cont, lv_pct(60), 0);
-    lv_obj_set_size(prompt_cont, lv_pct(60), lv_pct(50));
-    lv_obj_set_grid_dsc_array(prompt_cont, grid_main_col_dsc_detail, grid_main_row_dsc_detail);
-
-    lv_obj_set_style_pad_all(flex, 0, 0);
-
-    lv_obj_set_grid_cell(header,                LV_GRID_ALIGN_START,    0, 1, LV_GRID_ALIGN_START,  0, 1);
-    lv_obj_set_grid_cell(flex,                  LV_GRID_ALIGN_START,    0, 1, LV_GRID_ALIGN_CENTER, 1, 1);
-    lv_obj_set_grid_cell(footer_cont,          LV_GRID_ALIGN_CENTER,   0, 1, LV_GRID_ALIGN_END,    2, 1);
-
-    lv_obj_set_size(header, lv_pct(100), lv_pct(10));
-    lv_obj_set_size(flex, lv_pct(100), lv_pct(60));
-    lv_obj_set_size(footer_cont, lv_pct(100), lv_pct(15));
-
-    lv_obj_clear_flag(prompt_cont, LV_OBJ_FLAG_SCROLLABLE);
-    lv_obj_clear_flag(header, LV_OBJ_FLAG_SCROLLABLE);
-    lv_obj_clear_flag(flex, LV_OBJ_FLAG_SCROLLABLE);
-    lv_obj_clear_flag(footer_cont, LV_OBJ_FLAG_SCROLLABLE);
-
-
-    // set buttons horizontal
-    //
-    lv_style_init(&button_group_flex_style);
-    lv_style_set_flex_flow(&button_group_flex_style, LV_FLEX_FLOW_ROW);
-    lv_style_set_flex_main_place(&button_group_flex_style, LV_FLEX_ALIGN_SPACE_EVENLY);
-    lv_style_set_flex_cross_place(&button_group_flex_style, LV_FLEX_ALIGN_CENTER);
-    lv_style_set_flex_track_place(&button_group_flex_style, LV_FLEX_ALIGN_CENTER);
-    lv_style_set_layout(&button_group_flex_style, LV_LAYOUT_FLEX);
-    lv_style_set_pad_all(&button_group_flex_style, 0);
-    lv_style_set_height(&button_group_flex_style, LV_SIZE_CONTENT);
-    lv_style_set_width(&button_group_flex_style, lv_pct(100));
-    lv_style_set_outline_pad(&button_group_flex_style, 0);
-    lv_style_set_outline_width(&button_group_flex_style, 0);
-    lv_obj_add_style(footer_cont, &button_group_flex_style, 0);
-
-    static lv_style_t flex_style;
-    lv_style_init(&flex_style);
-    lv_style_set_flex_flow(&flex_style, LV_FLEX_FLOW_COLUMN_WRAP);
-    lv_style_set_flex_main_place(&flex_style, LV_FLEX_ALIGN_SPACE_EVENLY);
-    lv_style_set_flex_cross_place(&flex_style, LV_FLEX_ALIGN_CENTER);
-    lv_style_set_flex_track_place(&flex_style, LV_FLEX_ALIGN_CENTER);
-    lv_style_set_layout(&flex_style, LV_LAYOUT_FLEX);
-    lv_style_set_pad_all(&flex_style, 0);
-    lv_style_set_outline_pad(&flex_style, 0);
-    lv_style_set_outline_width(&flex_style, 0);
-    lv_obj_add_style(flex, &flex_style, 0);
-
-#ifdef DEBUG_LINES
-    // for debugging
-    lv_obj_set_style_border_width(header, 1, LV_PART_MAIN | LV_STATE_DEFAULT);
-    lv_obj_set_style_border_color(header, lv_palette_main(LV_PALETTE_RED), LV_PART_MAIN | LV_STATE_DEFAULT);
-    lv_obj_set_style_border_width(flex, 1, LV_PART_MAIN | LV_STATE_DEFAULT);
-    lv_obj_set_style_border_color(flex, lv_palette_main(LV_PALETTE_YELLOW), LV_PART_MAIN | LV_STATE_DEFAULT);
-    lv_obj_set_style_border_width(footer_cont, 1, LV_PART_MAIN | LV_STATE_DEFAULT);
-    lv_obj_set_style_border_color(footer_cont, lv_palette_main(LV_PALETTE_BLUE), LV_PART_MAIN | LV_STATE_DEFAULT);
+#ifdef DEBUG_BOXES
+  lv_obj_set_style_border_width(prompt_cont, 3, 0);
+  lv_obj_set_style_border_color(prompt_cont, lv_palette_main(LV_PALETTE_RED), 0);
 #endif
 
-    ws.register_notify_update(this);
-    ws.register_method_callback("notify_gcode_response", "MainPanel",[this](json& d) { this->handle_macro_response(d); });
+  static lv_coord_t grid_cols[] = {LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
+  static lv_coord_t grid_rows[] = {LV_GRID_CONTENT, LV_GRID_FR(1), LV_GRID_CONTENT, LV_GRID_TEMPLATE_LAST};
+  lv_obj_set_grid_dsc_array(prompt_cont, grid_cols, grid_rows);
 
-    // create header
-    lv_label_set_text(header, "HEADER");
+  lv_obj_set_grid_cell(header, LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_START, 0, 1);
+  lv_obj_set_grid_cell(body_cont, LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(footer_cont, LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_END, 2, 1);
 
-    // button styles
-    lv_style_init(&style_btn_grey);
-    lv_style_set_bg_color(&style_btn_grey, lv_palette_main(LV_PALETTE_GREY));
-    lv_style_set_bg_opa(&style_btn_grey, LV_OPA_COVER);
-    lv_style_set_pad_all(&style_btn_grey, 0);
+  // HEADER
+  lv_label_set_long_mode(header, LV_LABEL_LONG_SCROLL_CIRCULAR);
+  lv_obj_set_style_text_align(header, LV_TEXT_ALIGN_CENTER, 0);
+  lv_obj_set_style_pad_all(header, 0, 0);
+  lv_obj_set_style_pad_bottom(header, 4, 0);
+  lv_obj_set_style_border_width(header, 2, 0);
+  lv_obj_set_style_border_side(header, LV_BORDER_SIDE_BOTTOM, 0);
+  lv_obj_set_style_border_color(header, lv_palette_main(LV_PALETTE_GREY), 0);
 
-    lv_style_init(&style_btn_blue);
-    lv_style_set_bg_color(&style_btn_blue, lv_palette_main(LV_PALETTE_BLUE));
-    lv_style_set_bg_opa(&style_btn_blue, LV_OPA_COVER);
+#ifdef DEBUG_BOXES
+  lv_obj_set_style_border_width(header, 2, 0);
+  lv_obj_set_style_border_side(header, LV_BORDER_SIDE_FULL, 0);
+  lv_obj_set_style_border_color(header, lv_palette_main(LV_PALETTE_GREEN), 0);
+#endif
 
-    lv_style_init(&style_btn_red);
-    lv_style_set_bg_color(&style_btn_red, lv_palette_main(LV_PALETTE_RED));
-    lv_style_set_bg_opa(&style_btn_red, LV_OPA_COVER);
+  // BODY CONTAINER
+  lv_obj_set_style_pad_all(body_cont, 0, 0);
+  lv_obj_set_style_pad_ver(body_cont, 4, 0);
+  lv_obj_set_style_border_width(body_cont, 2, 0);
+  lv_obj_set_style_border_side(body_cont, LV_BORDER_SIDE_BOTTOM, 0);
+  lv_obj_set_style_border_color(body_cont, lv_palette_main(LV_PALETTE_GREY), 0);
+  lv_obj_set_flex_flow(body_cont, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_align(body_cont, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_START);
 
-    lv_style_init(&style_btn_orange);
-    lv_style_set_bg_color(&style_btn_orange, lv_palette_main(LV_PALETTE_ORANGE));
-    lv_style_set_bg_opa(&style_btn_orange, LV_OPA_COVER);
+#ifdef DEBUG_BOXES
+  lv_obj_set_style_border_width(body_cont, 2, 0);
+  lv_obj_set_style_border_side(body_cont, LV_BORDER_SIDE_FULL, 0);
+  lv_obj_set_style_border_color(body_cont, lv_palette_main(LV_PALETTE_YELLOW), 0);
+#endif
 
-    lv_style_init(&style_btn_dark_grey);
-    lv_style_set_bg_color(&style_btn_dark_grey, lv_palette_darken(LV_PALETTE_GREY, 1));
-    lv_style_set_bg_opa(&style_btn_dark_grey, LV_OPA_COVER);
-    
-    background(); // hide ourselves
-}
+  // BODY TEXT
+  lv_obj_set_width(body, LV_PCT(100));
+  lv_obj_set_style_pad_all(body, 0, 0);
+  lv_label_set_long_mode(body, LV_LABEL_LONG_WRAP);
 
+#ifdef DEBUG_BOXES
+  lv_obj_set_style_border_width(body, 2, 0);
+  lv_obj_set_style_border_side(body, LV_BORDER_SIDE_FULL, 0);
+  lv_obj_set_style_border_color(body, lv_palette_main(LV_PALETTE_PURPLE), 0);
+#endif
 
-void PromptPanel::consume(json &j) {
+  // BUTTONS
+  lv_obj_set_style_pad_all(button_cont, 0, 0);
+  lv_obj_set_style_pad_top(button_cont, 4, 0);
+  lv_obj_set_style_pad_column(button_cont, 8, 0);
+  lv_obj_set_style_pad_row(button_cont, 8, 0);
+  lv_obj_set_flex_flow(button_cont, LV_FLEX_FLOW_ROW_WRAP);
+  lv_obj_set_flex_align(button_cont, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+  lv_obj_set_size(button_cont, LV_PCT(100), LV_SIZE_CONTENT);
+  lv_obj_clear_flag(button_cont, LV_OBJ_FLAG_SCROLLABLE);
+
+#ifdef DEBUG_BOXES
+  lv_obj_set_style_border_width(button_cont, 2, 0);
+  lv_obj_set_style_border_side(button_cont, LV_BORDER_SIDE_FULL, 0);
+  lv_obj_set_style_border_color(button_cont, lv_palette_main(LV_PALETTE_TEAL), 0);
+#endif
+
+  // FOOTER
+  lv_obj_set_height(footer_cont, LV_SIZE_CONTENT);
+  lv_obj_set_width(footer_cont, LV_PCT(100));
+  lv_obj_set_flex_flow(footer_cont, LV_FLEX_FLOW_ROW);
+  lv_obj_set_flex_align(footer_cont,
+    LV_FLEX_ALIGN_START,
+    LV_FLEX_ALIGN_CENTER,
+    LV_FLEX_ALIGN_CENTER);
+  lv_obj_set_style_pad_all(footer_cont, 0, 0);
+  lv_obj_set_style_pad_top(footer_cont, 8, 0);
+  lv_obj_set_style_pad_column(footer_cont, 8, 0);
+
+#ifdef DEBUG_BOXES
+  lv_obj_set_style_border_width(footer_cont, 2, 0);
+  lv_obj_set_style_border_side(footer_cont, LV_BORDER_SIDE_FULL, 0);
+  lv_obj_set_style_border_color(footer_cont, lv_palette_main(LV_PALETTE_BLUE), 0);
+#endif
+
+  // BUTTON STYLES
+  auto init_btn_style = [](lv_style_t &st, lv_color_t c) {
+    lv_style_init(&st);
+    lv_style_set_bg_color(&st, c);
+    lv_style_set_bg_opa(&st, LV_OPA_COVER);
+    lv_style_set_pad_all(&st, 15);
+    };
+  init_btn_style(style_btn_grey, lv_palette_main(LV_PALETTE_GREY));
+  init_btn_style(style_btn_blue, lv_palette_main(LV_PALETTE_BLUE));
+  init_btn_style(style_btn_red, lv_palette_main(LV_PALETTE_RED));
+  init_btn_style(style_btn_orange, lv_palette_main(LV_PALETTE_ORANGE));
+  init_btn_style(style_btn_dark_grey, lv_palette_darken(LV_PALETTE_GREY, 1));
+
+  lv_obj_add_flag(prompt_cont, LV_OBJ_FLAG_HIDDEN);
+
+  ws.register_notify_update(this);
+  ws.register_method_callback(
+    "notify_gcode_response",
+    "PromptPanel",
+    [this](json &d) { consume(d); }
+  );
 }
 
 PromptPanel::~PromptPanel() {
-    if (prompt_cont != NULL) {
-        lv_obj_del(prompt_cont);
-        prompt_cont = NULL;
-    }
-
-    ws.unregister_notify_update(this);
+  if (prompt_cont) lv_obj_del(prompt_cont);
+  ws.unregister_notify_update(this);
 }
 
 void PromptPanel::foreground() {
-    // shrink wrap
-    lv_obj_move_foreground(prompt_cont);
+  lv_obj_clear_flag(prompt_cont, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_move_foreground(prompt_cont);
 }
 
 void PromptPanel::background() {
+  lv_obj_add_flag(prompt_cont, LV_OBJ_FLAG_HIDDEN);
   lv_obj_move_background(prompt_cont);
 }
 
-void PromptPanel::handle_callback(lv_event_t *event) {
-    lv_obj_t *btn = lv_event_get_current_target(event);
-
-    PromptPanel *panel = (PromptPanel*)event->user_data;
-
-    lv_obj_t *label = lv_obj_get_child(btn, 0);
-    lv_obj_t *command = lv_obj_get_child(btn, 1);
-    // check if btn in command map
-    spdlog::debug("handle event");
-
-    if (btn == NULL) {
-        spdlog::debug("no button found");
-    }
-
-    if (label != NULL) {
-        spdlog::debug("button: {}", lv_label_get_text(label));
-    }
-
-    if (command != NULL) {
-        std::string cmd = lv_label_get_text(command);
-        spdlog::debug("button: {}", cmd);
-        ws.gcode_script(cmd);
-    }
-
-
+void PromptPanel::on_button_click(lv_event_t *e) {
+  auto btn = lv_event_get_target(e);
+  auto pcmd = static_cast<std::string *>(btn->user_data);
+  auto panel = static_cast<PromptPanel *>(lv_event_get_user_data(e));
+  if (pcmd && !pcmd->empty()) {
+    panel->ws.gcode_script(*pcmd);
+    // consider `delete pcmd; btn->user_data = nullptr;` if one‐shot
+  }
 }
 
-void PromptPanel::check_height() {
-    // check if we need to increase size of the parent container
-    lv_obj_t *last_child = lv_obj_get_child(flex, -1);
-    // iterate max 5 times to enlarge, could probably be done nicer but since it's 
-    // based on css auto sizing is terrible.
-    if (NULL != last_child) {
-        int count = 0;
-        int y = lv_obj_get_y(last_child);
-        int height = lv_obj_get_height(last_child);
-        while(((y + height > lv_obj_get_height(flex)) || height == 0) && count < 5) {
-            spdlog::debug("y: {}, h: {}", y, height);
-            if ((y + height > lv_obj_get_height(flex)) || height == 0) {
-                int newheight = (int) (((double)lv_obj_get_height(prompt_cont)) * 1.1);
-                int newwidth = (int) (((double)lv_obj_get_width(prompt_cont)) * 1.1);
-                spdlog::debug("Increase size of panel: {}, {}", newheight, newwidth);
-                lv_obj_set_size(prompt_cont, newheight, newwidth);
-            }
-            lv_obj_update_layout(prompt_cont);
-            count++;
-            y = lv_obj_get_y(last_child);
-            height = lv_obj_get_height(last_child);
-        }
-    }
-}
+void PromptPanel::consume(json &j) {
+  auto &v = j["/params/0"_json_pointer];
+  if (!v.is_string()) return;
+  auto resp = v.get<std::string>();
+  if (resp.rfind("// action:", 0) != 0) return;
+  auto cmd = resp.substr(10);
 
-void PromptPanel::handle_macro_response(json &j) {
-    spdlog::trace("macro response: {}", j.dump());
-    auto &v = j["/params/0"_json_pointer];
+  std::lock_guard<std::mutex> guard(lv_lock);
 
-    if (!v.is_null()) {
-        spdlog::debug("data found");
-        std::string resp = v.template get<std::string>();
-        std::lock_guard<std::mutex> lock(lv_lock);
-        spdlog::debug("data: {}", resp);
+  if (cmd.rfind("prompt_begin", 0) == 0) {
+    lv_label_set_text(header, (std::string(LV_SYMBOL_WARNING) + " " + cmd.substr(13)).c_str());
 
-        if (resp.find("// action:", 0) == 0) {
-            // it is an action
-            std::string command = resp.substr(10);
-            spdlog::debug("action: {}", command);
+  } else if (cmd.rfind("prompt_text", 0) == 0) {
+    lv_label_set_text(body, cmd.substr(12).c_str());
 
-            
-            if (command.find("prompt_begin") == 0) {
-                std::string prompt_header = command.substr(13);
-                spdlog::debug("PROMPT_BEGIN: {}", prompt_header);
+  } else if (cmd.rfind("prompt_button", 0) == 0 || cmd.rfind("prompt_footer_button", 0) == 0) {
+    if (cmd.rfind("prompt_button_group", 0) == 0) return;
+    auto parts = KUtils::split(cmd, '|');
+    auto label = parts[0].substr(parts[0].find("button") + 6);
+    auto gcode = parts.size() > 1 ? parts[1] : "";
+    auto type = parts.size() > 2 ? parts[2] : "default";
 
-                // remove buttons
-                lv_obj_clean(footer_cont);
-                lv_obj_clean(flex);
-                // remove button commands
+    lv_obj_t *parent = (cmd.rfind("prompt_footer_button", 0) == 0) ? footer_cont : button_cont;
+    auto *b = lv_btn_create(parent);
+    if (type == "warning")      lv_obj_add_style(b, &style_btn_orange, 0);
+    else if (type == "error")   lv_obj_add_style(b, &style_btn_red, 0);
+    else if (type == "info")    lv_obj_add_style(b, &style_btn_blue, 0);
+    else if (type == "primary") lv_obj_add_style(b, &style_btn_blue, 0);
+    else                        lv_obj_add_style(b, &style_btn_dark_grey, 0);
 
-                lv_obj_set_size(prompt_cont, lv_pct(60), lv_pct(50));
-                lv_obj_set_height(flex, lv_pct(70));
+    auto *lbl = lv_label_create(b);
+    lv_label_set_text(lbl, label.c_str());
+    lv_obj_center(lbl);
 
-                // set header here
-                lv_label_set_text(header, prompt_header.c_str());
-            } else if (command.find("prompt_text") == 0) {
-                std::string prompt_text = command.substr(12);
-                spdlog::debug("PROMPT_TEXT: {}", prompt_text);
-                // create label and add to flex field
-                lv_obj_t *textfield = lv_label_create(flex);
-                lv_obj_set_width(textfield, lv_pct(96));
-                lv_obj_set_height(textfield, 40);
-                // lv_obj_set_style_min_height(textfield, 32, 0);
-                lv_label_set_long_mode(textfield, LV_LABEL_LONG_WRAP);
-                lv_obj_set_flex_grow(textfield, 1);
-                lv_obj_set_style_outline_pad(textfield, 0, 0);
-                lv_label_set_text(textfield, prompt_text.c_str());
-                lv_obj_center(textfield);
-#ifdef DEBUG_LINES
-                lv_obj_set_style_border_width(textfield, 1, LV_PART_MAIN | LV_STATE_DEFAULT);
-                lv_obj_set_style_border_color(textfield, lv_palette_main(LV_PALETTE_GREEN), LV_PART_MAIN | LV_STATE_DEFAULT);
-                lv_obj_set_style_bg_color(textfield, lv_palette_lighten(LV_PALETTE_GREEN, 2), LV_PART_MAIN | LV_STATE_DEFAULT);
-#endif
-            // due to using find, order IS important!  
-            } else if (command.find("prompt_button_group_start") == 0) {
-                spdlog::debug("Button group created");
-                // create new button group in flex window and mark active
-                button_group_cont = lv_obj_create(flex);
-                lv_obj_add_style(button_group_cont, &button_group_flex_style, 0);
-                lv_obj_set_flex_grow(button_group_cont, 1);
-                lv_obj_set_width(button_group_cont, lv_pct(96));
-                lv_obj_center(button_group_cont);
-                lv_obj_set_style_pad_all(button_group_cont, 0, 0);
-                lv_obj_set_style_outline_pad(button_group_cont, 0, 0);
-                lv_obj_set_style_max_height(button_group_cont, lv_pct(62), 0);
-                lv_obj_set_style_min_height(button_group_cont, 48, 0);
-                lv_obj_set_height(button_group_cont, LV_SIZE_CONTENT);
-                lv_obj_clear_flag(button_group_cont, LV_OBJ_FLAG_SCROLLABLE);
+    b->user_data = new std::string(gcode);
+    lv_obj_add_event_cb(b, PromptPanel::on_button_click, LV_EVENT_CLICKED, this);
 
-#ifdef DEBUG_LINES
-                lv_obj_set_style_border_width(button_group_cont, 1, LV_PART_MAIN | LV_STATE_DEFAULT);
-                lv_obj_set_style_border_color(button_group_cont, lv_palette_main(LV_PALETTE_PINK), LV_PART_MAIN | LV_STATE_DEFAULT);
-                lv_obj_set_style_bg_color(button_group_cont, lv_palette_lighten(LV_PALETTE_PINK, 2), LV_PART_MAIN | LV_STATE_DEFAULT);
-#endif
-                // lv_obj_set_style_min_height(button_group_cont, lv_pct(5), 0);
-            } else if (command.find("prompt_button_group_end") == 0) {
-                // does nothing since start creates a new one
-                spdlog::debug("Button group ended");
-                button_group_cont = NULL;
-            } else if (command.find("prompt_footer_button") == 0 || command.find("prompt_button") == 0) {
-                int index_label = command.find("button", 0) + strlen("button");
-                int index_first = command.find("|", index_label);
-                int index_second = command.find("|", index_first + 1);
-                spdlog::debug("indexes: {} {} {}", index_label, index_first, index_second);
-                std::string prompt_footer_button = command.substr(index_label, index_first - index_label);
-                std::string prompt_button_command;
-                std::string prompt_button_type = "none";
-                spdlog::debug("button: {} |  {} | {}", prompt_footer_button, prompt_button_command, prompt_button_type);
-                if (index_second > 0) {
-                    prompt_button_command = command.substr(index_first + 1, index_second - index_first - 1);
-                    prompt_button_type = command.substr(index_second + 1, command.length() - index_second - 1);
-                } else {
-                    prompt_button_command = command.substr(index_first + 1);
-                }
-                spdlog::debug("PROMPT_FOOTER_BUTTON: {} CMD: {}, type {}", prompt_footer_button, prompt_button_command, prompt_button_type);
-                lv_obj_t *btn = NULL;
-                if (command.find("prompt_footer_button") == 0) {
-                    btn = lv_btn_create(footer_cont);
-                } else {
-                    if (button_group_cont == NULL) {
-                        btn = lv_btn_create(flex);
-                    } else {
-                        btn = lv_btn_create(button_group_cont);
-                    }
-                }
-                if (btn) {
-                    lv_obj_set_size(btn, lv_pct(45), 32);
-                    lv_obj_set_style_max_width(btn, lv_pct(45), 0);
-                    lv_obj_set_style_min_width(btn, 32, 0);
-                    lv_obj_set_style_max_height(btn, 54, 0);
-                    lv_obj_set_style_min_height(btn, 42, 0);
-                    lv_obj_set_style_outline_pad(btn, 0, 0);
-                    lv_obj_center(btn);
-                    lv_obj_set_flex_grow(btn, 1);
-                    lv_obj_t *label = lv_label_create(btn);
-                    // a hidden label is abused to transfer the command and auto-clean it
-                    lv_obj_t *command = lv_label_create(btn);
-                    lv_obj_set_size(command, 1, 1);
-                    lv_obj_add_flag(command, LV_OBJ_FLAG_HIDDEN);
-                    lv_label_set_text(label, prompt_footer_button.c_str());
-                    lv_label_set_text(command, prompt_button_command.c_str());
-                    lv_obj_set_style_pad_all(btn, 2, 0);
-                    // lv_obj_set_style_max_width(label, lv_pct(45), 0);
-                    lv_obj_center(label);
+  } else if (cmd == "prompt_show") {
+    lv_obj_update_layout(prompt_cont);
+    foreground();
 
-                    if (!prompt_button_type.compare("secondary")) {
-                        spdlog::debug("type secondary");
-                        lv_obj_add_style(btn, &style_btn_grey, 0);
-                    } else if (!prompt_button_type.compare("warning")) {
-                        spdlog::debug("type warning");
-                        lv_obj_add_style(btn, &style_btn_orange, 0);
-                    } else if (!prompt_button_type.compare("error")) {
-                        spdlog::debug("type error");
-                        lv_obj_add_style(btn, &style_btn_red, 0);
-                    } else if (!prompt_button_type.compare("info")) {
-                        spdlog::debug("type info");
-                        lv_obj_add_style(btn, &style_btn_blue, 0);
-                    } else if (!prompt_button_type.compare("primary")) {
-                        spdlog::debug("type primary");
-                        lv_obj_add_style(btn, &style_btn_blue, 0);
-                    } else { // info and primary as well
-                        spdlog::debug("type default");
-                        lv_obj_add_style(btn, &style_btn_dark_grey, 0);
-                    }
-                    lv_obj_add_event_cb(btn, _handle_callback, LV_EVENT_PRESSED, this);
-
-                }
-            } else if (command.find("prompt_show") == 0) {
-                spdlog::debug("PROMPT_SHOW");
-                check_height();
-                foreground();
-            } else if (command.find("prompt_end") == 0) {
-                spdlog::debug("PROMPT_END");
-                background();
-
-                // remove buttons
-                lv_obj_clean(footer_cont);
-                lv_obj_clean(flex);
-                lv_obj_set_size(prompt_cont, lv_pct(60), lv_pct(50));
-                lv_obj_set_height(flex, LV_SIZE_CONTENT);
-            } else {
-                spdlog::debug("action {} --- not supported", command);
-            }
-            
-        }
-        
-    }
+  } else if (cmd == "prompt_end") {
+    lv_label_set_text(header, "");
+    lv_label_set_text(body, "");
+    lv_obj_clean(button_cont);
+    lv_obj_clean(footer_cont);
+    lv_obj_scroll_to_y(body_cont, 0, LV_ANIM_OFF);
+    background();
+  }
 }

--- a/src/prompt_panel.h
+++ b/src/prompt_panel.h
@@ -10,42 +10,24 @@
 #include <memory>
 #include <mutex>
 
-struct SharedButton {
-    SharedButton(lv_obj_t *bbtn) : btn(bbtn) {};
-    lv_obj_t *btn;
-};
-
 class PromptPanel : public NotifyConsumer {
     public:
         PromptPanel(KWebSocketClient &ws, std::mutex &lock, lv_obj_t *parent);
         ~PromptPanel();
-
-        void handle_macro_response(json &j);
         void consume(json &j);
-
-        lv_obj_t *get_container();
-        void handle_callback(lv_event_t *event);
-
-        static void _handle_callback(lv_event_t *event) {
-            PromptPanel *panel = (PromptPanel*)event->user_data;
-            panel->handle_callback(event);
-        };
-
         void foreground();
         void background();
 
     private:
-
-        void check_height();
+        static void on_button_click(lv_event_t *e);
 
         KWebSocketClient &ws;
-        lv_obj_t *promptpanel_cont;
         lv_obj_t *prompt_cont;
-        lv_obj_t *flex;
         lv_obj_t *header;
-        lv_obj_t *button_group_cont;
+        lv_obj_t *body_cont;
+        lv_obj_t *body;
+        lv_obj_t *button_cont;
         lv_obj_t *footer_cont;
-
 };
 
 #endif // __PROMPT_PANEL_H__

--- a/src/sensor_container.cpp
+++ b/src/sensor_container.cpp
@@ -4,17 +4,17 @@
 #include <string>
 
 SensorContainer::SensorContainer(KWebSocketClient &c,
-				 lv_obj_t *parent,
-				 const void *img,
-				 const char *text,
-				 lv_color_t color,
-				 bool can_edit,
-				 bool show_target,
-				 Numpad &np,
-				 std::string name,
-				 lv_obj_t *chart_chart,
-				 lv_chart_series_t *chart_series,
-				 SensorType type)
+  lv_obj_t *parent,
+  const void *img,
+  const char *text,
+  lv_color_t color,
+  bool can_edit,
+  bool show_target,
+  Numpad &np,
+  std::string name,
+  lv_obj_t *chart_chart,
+  lv_chart_series_t *chart_series,
+  SensorType type)
   : ws(c)
   , sensor_cont(lv_obj_create(parent))
   , sensor_img(lv_img_create(sensor_cont))
@@ -31,72 +31,72 @@ SensorContainer::SensorContainer(KWebSocketClient &c,
   , last_updated_ts(std::time(nullptr))
   , type(type)
 {
-    lv_obj_clear_flag(sensor_cont, LV_OBJ_FLAG_SCROLLABLE);
-    lv_obj_set_style_border_color(sensor_cont, color, LV_PART_MAIN);
-    lv_obj_set_style_border_side(sensor_cont, LV_BORDER_SIDE_LEFT, LV_PART_MAIN);
-    lv_obj_set_style_border_width(sensor_cont, 5, LV_PART_MAIN);
+  lv_obj_clear_flag(sensor_cont, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_style_border_color(sensor_cont, color, LV_PART_MAIN);
+  lv_obj_set_style_border_side(sensor_cont, LV_BORDER_SIDE_LEFT, LV_PART_MAIN);
+  lv_obj_set_style_border_width(sensor_cont, 5, LV_PART_MAIN);
 
-    // auto cont_width = (double)lv_disp_get_physical_hor_res(NULL) * 0.4125;
-    // cont_width = cont_width > 330 ? 330 : cont_width;
-    // auto cont_height = (double)lv_disp_get_physical_ver_res(NULL) * 0.125;
-    // cont_height = cont_height > 60 ? 60 : cont_height;
+  // auto cont_width = (double)lv_disp_get_physical_hor_res(NULL) * 0.4125;
+  // cont_width = cont_width > 330 ? 330 : cont_width;
+  // auto cont_height = (double)lv_disp_get_physical_ver_res(NULL) * 0.125;
+  // cont_height = cont_height > 60 ? 60 : cont_height;
 
-    auto width_scale = (double)lv_disp_get_physical_hor_res(NULL) / 800.0;
-    auto height_scale = (double)lv_disp_get_physical_ver_res(NULL) / 480.0;
-    lv_obj_set_size(sensor_cont, 330 * width_scale, 60 * height_scale);
-    lv_obj_set_style_pad_all(sensor_cont, 0, 0);
+  auto width_scale = (double)lv_disp_get_physical_hor_res(NULL) / 800.0;
+  auto height_scale = (double)lv_disp_get_physical_ver_res(NULL) / 480.0;
+  lv_obj_set_size(sensor_cont, 330 * width_scale, 60 * height_scale);
+  lv_obj_set_style_pad_all(sensor_cont, 0, 0);
 
-    lv_img_set_src(sensor_img, img);
-    lv_obj_align(sensor_img, LV_ALIGN_LEFT_MID, 0, 0);
+  lv_img_set_src(sensor_img, img);
+  lv_obj_align(sensor_img, LV_ALIGN_LEFT_MID, 0, 0);
 
-    lv_label_set_text(sensor_label, text);
-    lv_obj_align_to(sensor_label, sensor_img, LV_ALIGN_OUT_RIGHT_MID, -7 * width_scale, 0);
+  lv_label_set_text(sensor_label, text);
+  lv_obj_align_to(sensor_label, sensor_img, LV_ALIGN_OUT_RIGHT_MID, -7 * width_scale, 0);
 
-    lv_label_set_text(value_label, "0");
-    lv_obj_set_width(value_label, 55 * width_scale);
-    lv_obj_align(value_label, LV_ALIGN_RIGHT_MID, -75 * width_scale, 0);
-    lv_label_set_long_mode(value_label, LV_LABEL_LONG_CLIP);
-    lv_obj_set_style_pad_all(value_label, 8 * width_scale, 0);
+  lv_label_set_text(value_label, "0");
+  lv_obj_set_width(value_label, 55 * width_scale);
+  lv_obj_align(value_label, LV_ALIGN_RIGHT_MID, -75 * width_scale, 0);
+  lv_label_set_long_mode(value_label, LV_LABEL_LONG_CLIP);
+  lv_obj_set_style_pad_all(value_label, 8 * width_scale, 0);
 
-    lv_label_set_text(divider_label, "/");
-    lv_obj_set_width(divider_label, 50 * width_scale);
-    lv_obj_align(divider_label, LV_ALIGN_RIGHT_MID, -32 * width_scale, 0);
-    lv_obj_set_style_pad_all(divider_label, 8 * width_scale, 0);
+  lv_label_set_text(divider_label, "/");
+  lv_obj_set_width(divider_label, 50 * width_scale);
+  lv_obj_align(divider_label, LV_ALIGN_RIGHT_MID, -32 * width_scale, 0);
+  lv_obj_set_style_pad_all(divider_label, 8 * width_scale, 0);
 
-    if (show_target || can_edit) {
-      lv_label_set_text(target_label, "0");
-      lv_obj_set_width(target_label, 60 * width_scale);
-      lv_obj_align(target_label, LV_ALIGN_RIGHT_MID, 0, 0);
-      lv_obj_set_style_pad_all(target_label, 8 * width_scale, 0);
-    } else {
-      lv_obj_add_flag(target_label, LV_OBJ_FLAG_HIDDEN);
-      lv_obj_add_flag(divider_label, LV_OBJ_FLAG_HIDDEN);
-    }
+  if (show_target || can_edit) {
+    lv_label_set_text(target_label, "0");
+    lv_obj_set_width(target_label, 60 * width_scale);
+    lv_obj_align(target_label, LV_ALIGN_RIGHT_MID, 0, 0);
+    lv_obj_set_style_pad_all(target_label, 8 * width_scale, 0);
+  } else {
+    lv_obj_add_flag(target_label, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(divider_label, LV_OBJ_FLAG_HIDDEN);
+  }
 
-    if (can_edit) {
-      lv_obj_set_style_border_width(target_label, 2, LV_PART_MAIN);
-      lv_obj_set_style_radius(target_label, 6, LV_PART_MAIN);
-      lv_obj_set_style_border_color(target_label, lv_palette_darken(LV_PALETTE_GREY, 1), LV_PART_MAIN);
+  if (can_edit) {
+    lv_obj_set_style_border_width(target_label, 2, LV_PART_MAIN);
+    lv_obj_set_style_radius(target_label, 6, LV_PART_MAIN);
+    lv_obj_set_style_border_color(target_label, lv_palette_darken(LV_PALETTE_GREY, 1), LV_PART_MAIN);
 
-      spdlog::debug("sensor cb registered name {}, cont {}, this {}, np {}",
-		    id, fmt::ptr(sensor_cont), fmt::ptr(this), fmt::ptr(&np));
-      lv_obj_add_event_cb(sensor_cont, &SensorContainer::_handle_edit, LV_EVENT_CLICKED, this);
-    }
+    spdlog::debug("sensor cb registered name {}, cont {}, this {}, np {}",
+      id, fmt::ptr(sensor_cont), fmt::ptr(this), fmt::ptr(&np));
+    lv_obj_add_event_cb(sensor_cont, &SensorContainer::_handle_edit, LV_EVENT_CLICKED, this);
+  }
 }
 
 SensorContainer::SensorContainer(KWebSocketClient &c,
-				 lv_obj_t *parent,
-				 const void *img,
-				 uint16_t img_scale,
-				 const char *text,
-				 lv_color_t color,
-				 bool can_edit,
-				 bool show_target,
-				 Numpad &np,
-				 std::string name,
-				 lv_obj_t *chart,
-         lv_chart_series_t *chart_series,
-         SensorType type)
+  lv_obj_t *parent,
+  const void *img,
+  uint16_t img_scale,
+  const char *text,
+  lv_color_t color,
+  bool can_edit,
+  bool show_target,
+  Numpad &np,
+  std::string name,
+  lv_obj_t *chart,
+  lv_chart_series_t *chart_series,
+  SensorType type)
   : SensorContainer(c, parent, img, text, color, can_edit, show_target, np, name, chart, chart_series, type)
 {
   lv_img_set_zoom(sensor_img, img_scale);

--- a/src/sensor_container.h
+++ b/src/sensor_container.h
@@ -14,33 +14,33 @@ enum class SensorType {
 };
 
 class SensorContainer {
- public:
+public:
   SensorContainer(KWebSocketClient &c,
-		  lv_obj_t *parent,
-		  const void *img,
-		  const char *text,
-		  lv_color_t color,
-      bool editable,
-      bool show_target,
-		  Numpad &np,
-		  std::string name,
-		  lv_obj_t *chart,
-		  lv_chart_series_t *chart_series,
-      SensorType type = SensorType::Heater);
+    lv_obj_t *parent,
+    const void *img,
+    const char *text,
+    lv_color_t color,
+    bool editable,
+    bool show_target,
+    Numpad &np,
+    std::string name,
+    lv_obj_t *chart,
+    lv_chart_series_t *chart_series,
+    SensorType type = SensorType::Heater);
 
   SensorContainer(KWebSocketClient &c,
-		  lv_obj_t *parent,
-		  const void *img,
-		  uint16_t img_scale,
-		  const char *text,
-		  lv_color_t color,
-		  bool editable,
-		  bool show_target,
-		  Numpad &np,
-		  std::string name,
-		  lv_obj_t *chart,
-      lv_chart_series_t *chart_series,
-      SensorType type = SensorType::Heater);
+    lv_obj_t *parent,
+    const void *img,
+    uint16_t img_scale,
+    const char *text,
+    lv_color_t color,
+    bool editable,
+    bool show_target,
+    Numpad &np,
+    std::string name,
+    lv_obj_t *chart,
+    lv_chart_series_t *chart_series,
+    SensorType type = SensorType::Heater);
 
   ~SensorContainer();
 
@@ -51,11 +51,11 @@ class SensorContainer {
   void handle_edit(lv_event_t *event);
 
   static void _handle_edit(lv_event_t *event) {
-    SensorContainer *panel = (SensorContainer*)event->user_data;
+    SensorContainer *panel = (SensorContainer *)event->user_data;
     panel->handle_edit(event);
   };
 
- private:
+private:
   KWebSocketClient &ws;
   lv_obj_t *sensor_cont;
   lv_obj_t *sensor_img;

--- a/src/sensor_container.h
+++ b/src/sensor_container.h
@@ -7,6 +7,12 @@
 
 #include <ctime>
 
+enum class SensorType {
+  Heater,
+  TempFan,
+  Sensor
+};
+
 class SensorContainer {
  public:
   SensorContainer(KWebSocketClient &c,
@@ -14,13 +20,14 @@ class SensorContainer {
 		  const void *img,
 		  const char *text,
 		  lv_color_t color,
-		  bool editable,
-		  bool show_target,
+      bool editable,
+      bool show_target,
 		  Numpad &np,
 		  std::string name,
 		  lv_obj_t *chart,
-		  lv_chart_series_t *chart_series);
-		  
+		  lv_chart_series_t *chart_series,
+      SensorType type = SensorType::Heater);
+
   SensorContainer(KWebSocketClient &c,
 		  lv_obj_t *parent,
 		  const void *img,
@@ -32,8 +39,9 @@ class SensorContainer {
 		  Numpad &np,
 		  std::string name,
 		  lv_obj_t *chart,
-		  lv_chart_series_t *chart_series);
-  
+      lv_chart_series_t *chart_series,
+      SensorType type = SensorType::Heater);
+
   ~SensorContainer();
 
   lv_obj_t *get_sensor();
@@ -62,7 +70,7 @@ class SensorContainer {
   lv_obj_t *chart;
   lv_chart_series_t *series;
   std::time_t last_updated_ts;
-  
+  SensorType type;
 };
 
 #endif // __SENSOR_CONTAINER_H__

--- a/src/setting_panel.cpp
+++ b/src/setting_panel.cpp
@@ -58,10 +58,10 @@ SettingPanel::SettingPanel(KWebSocketClient &c, std::mutex &l, lv_obj_t *parent,
   lv_obj_set_grid_dsc_array(cont, grid_main_col_dsc, grid_main_row_dsc);
 
   // row 1
-  lv_obj_set_grid_cell(guppy_update_btn.get_container(), LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
-  lv_obj_set_grid_cell(guppy_restart_btn.get_container(), LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
-  lv_obj_set_grid_cell(restart_klipper_btn.get_container(), LV_GRID_ALIGN_STRETCH, 2, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
-  lv_obj_set_grid_cell(restart_firmware_btn.get_container(), LV_GRID_ALIGN_STRETCH, 3, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(restart_klipper_btn.get_container(), LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(restart_firmware_btn.get_container(), LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(guppy_restart_btn.get_container(), LV_GRID_ALIGN_STRETCH, 2, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(guppy_update_btn.get_container(), LV_GRID_ALIGN_STRETCH, 3, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
 
   // row 2
   lv_obj_set_grid_cell(wifi_btn.get_container(), LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 2, 1);

--- a/src/setting_panel.cpp
+++ b/src/setting_panel.cpp
@@ -50,9 +50,9 @@ SettingPanel::SettingPanel(KWebSocketClient &c, std::mutex &l, lv_obj_t *parent,
   wifi_btn.disable();
 #endif
 
-  static lv_coord_t grid_main_row_dsc[] = { LV_GRID_FR(1), LV_GRID_FR(5), LV_GRID_FR(5), LV_GRID_FR(1),
-    LV_GRID_TEMPLATE_LAST };
-  static lv_coord_t grid_main_col_dsc[] = { LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1),
+  static lv_coord_t grid_main_row_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(5), LV_GRID_FR(5), LV_GRID_FR(1),
+    LV_GRID_TEMPLATE_LAST};
+  static lv_coord_t grid_main_col_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1),
     LV_GRID_TEMPLATE_LAST};
 
   lv_obj_set_grid_dsc_array(cont, grid_main_col_dsc, grid_main_row_dsc);
@@ -111,7 +111,7 @@ void SettingPanel::handle_callback(lv_event_t *event) {
       if (fs::exists(script) || init_script.rfind("service guppyscreen", 0) == 0) {
         sp::call({init_script, "restart"});
       } else {
-        	spdlog::warn("Failed to restart Guppy Screen. Did not find restart script.");
+        spdlog::warn("Failed to restart Guppy Screen. Did not find restart script.");
       }
     } else if (btn == guppy_update_btn.get_container()) {
       spdlog::trace("update guppy pressed");
@@ -119,9 +119,9 @@ void SettingPanel::handle_callback(lv_event_t *event) {
       auto update_script = fs::canonical("/proc/self/exe").parent_path() / "update.sh";
       const fs::path script(update_script);
       if (fs::exists(script)) {
-	sp::call(script);
+        sp::call(script);
       } else {
-	spdlog::warn("Failed to update Guppy Screen. Did not find update script.");
+        spdlog::warn("Failed to update Guppy Screen. Did not find update script.");
       }
     } else if (btn == printer_select_btn.get_container()) {
       spdlog::trace("setting printers pressed");

--- a/src/setting_panel.cpp
+++ b/src/setting_panel.cpp
@@ -30,7 +30,7 @@ SettingPanel::SettingPanel(KWebSocketClient &c, std::mutex &l, lv_obj_t *parent,
   , sysinfo_panel()
   , spoolman_panel(sm)
   , wifi_btn(cont, &network_img, "WIFI", &SettingPanel::_handle_callback, this)
-  , restart_klipper_btn(cont, &refresh_img, "Restart Klipper", &SettingPanel::_handle_callback, this)
+  , restart_klipper_btn(cont, &refresh_img, "Restart\nKlipper", &SettingPanel::_handle_callback, this)
   , restart_firmware_btn(cont, &refresh_img, "Restart\nFirmware", &SettingPanel::_handle_callback, this)
 #ifdef ZBOLT
   , sysinfo_btn(cont, &info_img, "System", &SettingPanel::_handle_callback, this)
@@ -38,8 +38,8 @@ SettingPanel::SettingPanel(KWebSocketClient &c, std::mutex &l, lv_obj_t *parent,
   , sysinfo_btn(cont, &sysinfo_img, "System", &SettingPanel::_handle_callback, this)
 #endif
   , spoolman_btn(cont, &spoolman_img, "Spoolman", &SettingPanel::_handle_callback, this)
-  , guppy_restart_btn(cont, &refresh_img, "Restart Guppy", &SettingPanel::_handle_callback, this)
-  , guppy_update_btn(cont, &update_img, "Update Guppy", &SettingPanel::_handle_callback, this)
+  , guppy_restart_btn(cont, &refresh_img, "Restart\nGuppy", &SettingPanel::_handle_callback, this)
+  , guppy_update_btn(cont, &update_img, "Update\nGuppy", &SettingPanel::_handle_callback, this)
   , printer_select_btn(cont, &print, "Printers", &SettingPanel::_handle_callback, this)
 {
   lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLLABLE);
@@ -50,24 +50,25 @@ SettingPanel::SettingPanel(KWebSocketClient &c, std::mutex &l, lv_obj_t *parent,
   wifi_btn.disable();
 #endif
 
-  static lv_coord_t grid_main_row_dsc[] = {LV_GRID_FR(2), LV_GRID_FR(5), LV_GRID_FR(5), LV_GRID_TEMPLATE_LAST};
-  static lv_coord_t grid_main_col_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1),
-      LV_GRID_TEMPLATE_LAST};
+  static lv_coord_t grid_main_row_dsc[] = { LV_GRID_FR(1), LV_GRID_FR(5), LV_GRID_FR(5), LV_GRID_FR(1),
+    LV_GRID_TEMPLATE_LAST };
+  static lv_coord_t grid_main_col_dsc[] = { LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1),
+    LV_GRID_TEMPLATE_LAST};
 
   lv_obj_set_grid_dsc_array(cont, grid_main_col_dsc, grid_main_row_dsc);
 
   // row 1
-  lv_obj_set_grid_cell(wifi_btn.get_container(), LV_GRID_ALIGN_CENTER, 0, 1, LV_GRID_ALIGN_START, 1, 1);
-  lv_obj_set_grid_cell(restart_klipper_btn.get_container(), LV_GRID_ALIGN_CENTER, 1, 1, LV_GRID_ALIGN_START, 1, 1);
-  lv_obj_set_grid_cell(restart_firmware_btn.get_container(), LV_GRID_ALIGN_CENTER, 2, 1, LV_GRID_ALIGN_START, 1, 1);
-  lv_obj_set_grid_cell(sysinfo_btn.get_container(), LV_GRID_ALIGN_CENTER, 3, 1, LV_GRID_ALIGN_START, 1, 1);
+  lv_obj_set_grid_cell(guppy_update_btn.get_container(), LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(guppy_restart_btn.get_container(), LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(restart_klipper_btn.get_container(), LV_GRID_ALIGN_STRETCH, 2, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
+  lv_obj_set_grid_cell(restart_firmware_btn.get_container(), LV_GRID_ALIGN_STRETCH, 3, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
 
   // row 2
-  lv_obj_set_grid_cell(spoolman_btn.get_container(), LV_GRID_ALIGN_CENTER, 0, 1, LV_GRID_ALIGN_START, 2, 1);
-  lv_obj_set_grid_cell(guppy_restart_btn.get_container(), LV_GRID_ALIGN_CENTER, 1, 1, LV_GRID_ALIGN_START, 2, 1);
-  lv_obj_set_grid_cell(guppy_update_btn.get_container(), LV_GRID_ALIGN_CENTER, 2, 1, LV_GRID_ALIGN_START, 2, 1);
-  lv_obj_set_grid_cell(printer_select_btn.get_container(), LV_GRID_ALIGN_CENTER, 3, 1, LV_GRID_ALIGN_START, 2, 1);
-  
+  lv_obj_set_grid_cell(wifi_btn.get_container(), LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 2, 1);
+  lv_obj_set_grid_cell(printer_select_btn.get_container(), LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH, 2, 1);
+  lv_obj_set_grid_cell(spoolman_btn.get_container(), LV_GRID_ALIGN_STRETCH, 2, 1, LV_GRID_ALIGN_STRETCH, 2, 1);
+  lv_obj_set_grid_cell(sysinfo_btn.get_container(), LV_GRID_ALIGN_STRETCH, 3, 1, LV_GRID_ALIGN_STRETCH, 2, 1);
+
 }
 
 SettingPanel::~SettingPanel() {

--- a/src/slider_container.cpp
+++ b/src/slider_container.cpp
@@ -2,66 +2,66 @@
 #include "spdlog/spdlog.h"
 
 SliderContainer::SliderContainer(lv_obj_t *parent,
-				 const char *label_text,
-				 const void *off_btn_img,
-				 const char *off_text,
-				 const void *max_btn_img,
-				 const char *max_text,
-				 lv_event_cb_t cb,
-				 void *user_data)
+  const char *label_text,
+  const void *off_btn_img,
+  const char *off_text,
+  const void *max_btn_img,
+  const char *max_text,
+  lv_event_cb_t cb,
+  void *user_data)
   : SliderContainer(parent,
-		    label_text,
-		    off_btn_img,
-		    off_text,
-		    cb,
-		    user_data,
-		    max_btn_img,
-		    max_text,
-		    cb,
-		    user_data,
-		    cb,
-		    user_data,
-		    "%") {
+  label_text,
+  off_btn_img,
+  off_text,
+  cb,
+  user_data,
+  max_btn_img,
+  max_text,
+  cb,
+  user_data,
+  cb,
+  user_data,
+  "%") {
 }
 
 SliderContainer::SliderContainer(lv_obj_t *parent,
-				 const char *label_text,
-				 const void *off_btn_img,
-				 const char *off_text,
-				 const void *max_btn_img,
-				 const char *max_text,
-				 lv_event_cb_t cb,
-				 void *user_data,
-				 std::string u)
+  const char *label_text,
+  const void *off_btn_img,
+  const char *off_text,
+  const void *max_btn_img,
+  const char *max_text,
+  lv_event_cb_t cb,
+  void *user_data,
+  std::string u)
   : SliderContainer(parent,
-		    label_text,
-		    off_btn_img,
-		    off_text,
-		    cb,
-		    user_data,
-		    max_btn_img,
-		    max_text,
-		    cb,
-		    user_data,
-		    cb,
-		    user_data,
-		    u) {
+  label_text,
+  off_btn_img,
+  off_text,
+  cb,
+  user_data,
+  max_btn_img,
+  max_text,
+  cb,
+  user_data,
+  cb,
+  user_data,
+  u) {
 }
 
 
 SliderContainer::SliderContainer(lv_obj_t *parent,
-				 const char *label_text,
-				 const void *off_btn_img,
-				 const char *off_text,
-				 lv_event_cb_t off_cb,
-				 void * off_cb_user_data,
-				 const void *max_btn_img,
-				 const char *max_text,
-				 lv_event_cb_t max_cb,
-				 void * max_cb_user_data,
-				 lv_event_cb_t slider_cb,
-				 void * slider_user_data,
-				 std::string u)
+  const char *label_text,
+  const void *off_btn_img,
+  const char *off_text,
+  lv_event_cb_t off_cb,
+  void * off_cb_user_data,
+  const void *max_btn_img,
+  const char *max_text,
+  lv_event_cb_t max_cb,
+  void * max_cb_user_data,
+  lv_event_cb_t slider_cb,
+  void * slider_user_data,
+  std::string u)
   : cont(lv_obj_create(parent))
   , label(lv_label_create(cont))
   , control_cont(lv_obj_create(cont))
@@ -82,7 +82,7 @@ SliderContainer::SliderContainer(lv_obj_t *parent,
   lv_obj_align(cont, LV_ALIGN_CENTER, 0, 0);
 
   lv_label_set_text(label, label_text);
-  lv_obj_set_width(label, LV_PCT(100));  
+  lv_obj_set_width(label, LV_PCT(100));
 
   lv_obj_clear_flag(control_cont, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_size(control_cont, lv_pct(100), LV_SIZE_CONTENT);
@@ -91,16 +91,20 @@ SliderContainer::SliderContainer(lv_obj_t *parent,
   lv_obj_set_style_pad_all(control_cont, 0, 0);
   lv_obj_set_style_pad_bottom(control_cont, 7, 0);
 
-  lv_obj_clear_flag(slider_cont, LV_OBJ_FLAG_SCROLLABLE);    
-  lv_obj_set_size(slider_cont, LV_PCT(45), LV_SIZE_CONTENT);
+  lv_obj_clear_flag(slider_cont, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_size(slider_cont, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
+  lv_obj_set_flex_grow(slider_cont, 1);
   lv_obj_set_style_pad_all(slider_cont, 0, 0);
+  lv_obj_set_style_pad_left(slider_cont, 12, 0);
+  lv_obj_set_style_pad_right(slider_cont, 12, 0);
 
   lv_obj_align(slider, LV_ALIGN_CENTER, 0, 0);
-  lv_obj_set_width(slider, LV_PCT(85));
+  lv_obj_set_width(slider, LV_PCT(100));
   lv_obj_align_to(slider_value, slider, LV_ALIGN_OUT_BOTTOM_MID, 0, 10);
 
   if (max_text == NULL) {
-    max_btn.hide();
+    lv_obj_set_style_opa(max_btn.get_container(), LV_OPA_0, 0);
+    max_btn.disable();
   }
 
   if (slider_cb != NULL) {
@@ -108,7 +112,7 @@ SliderContainer::SliderContainer(lv_obj_t *parent,
   }
 
   lv_obj_add_event_cb(slider, &SliderContainer::_handle_value_update,
-		      LV_EVENT_VALUE_CHANGED, this);
+    LV_EVENT_VALUE_CHANGED, this);
 }
 
 SliderContainer::~SliderContainer() {

--- a/src/slider_container.cpp
+++ b/src/slider_container.cpp
@@ -10,18 +10,18 @@ SliderContainer::SliderContainer(lv_obj_t *parent,
   lv_event_cb_t cb,
   void *user_data)
   : SliderContainer(parent,
-  label_text,
-  off_btn_img,
-  off_text,
-  cb,
-  user_data,
-  max_btn_img,
-  max_text,
-  cb,
-  user_data,
-  cb,
-  user_data,
-  "%") {
+    label_text,
+    off_btn_img,
+    off_text,
+    cb,
+    user_data,
+    max_btn_img,
+    max_text,
+    cb,
+    user_data,
+    cb,
+    user_data,
+    "%") {
 }
 
 SliderContainer::SliderContainer(lv_obj_t *parent,
@@ -34,18 +34,18 @@ SliderContainer::SliderContainer(lv_obj_t *parent,
   void *user_data,
   std::string u)
   : SliderContainer(parent,
-  label_text,
-  off_btn_img,
-  off_text,
-  cb,
-  user_data,
-  max_btn_img,
-  max_text,
-  cb,
-  user_data,
-  cb,
-  user_data,
-  u) {
+    label_text,
+    off_btn_img,
+    off_text,
+    cb,
+    user_data,
+    max_btn_img,
+    max_text,
+    cb,
+    user_data,
+    cb,
+    user_data,
+    u) {
 }
 
 
@@ -54,13 +54,13 @@ SliderContainer::SliderContainer(lv_obj_t *parent,
   const void *off_btn_img,
   const char *off_text,
   lv_event_cb_t off_cb,
-  void * off_cb_user_data,
+  void *off_cb_user_data,
   const void *max_btn_img,
   const char *max_text,
   lv_event_cb_t max_cb,
-  void * max_cb_user_data,
+  void *max_cb_user_data,
   lv_event_cb_t slider_cb,
-  void * slider_user_data,
+  void *slider_user_data,
   std::string u)
   : cont(lv_obj_create(parent))
   , label(lv_label_create(cont))
@@ -149,6 +149,6 @@ void SliderContainer::update_value(int value) {
 }
 
 void SliderContainer::handle_value_update(lv_event_t *event) {
-  lv_obj_t * obj = lv_event_get_target(event);
+  lv_obj_t *obj = lv_event_get_target(event);
   update_value((int)lv_slider_get_value(obj));
 }

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -90,7 +90,7 @@ std::vector<std::string> State::get_extruders() {
 
   return extruders;
 }
-  
+
 std::vector<std::string> State::get_heaters() {
   std::lock_guard<std::mutex> guard(lock);
   auto &objects = data["/printer_objs/objects"_json_pointer];
@@ -116,8 +116,8 @@ std::vector<std::string> State::get_sensors() {
     for (auto &o : objects) {
       const std::string &obj_name = o.template get<std::string>();
       if (obj_name.rfind("temperature_sensor ", 0) == 0
-	  || obj_name.rfind("temperature_fan ", 0) == 0) {
-	sensors.push_back(obj_name);
+        || obj_name.rfind("temperature_fan ", 0) == 0) {
+        sensors.push_back(obj_name);
       }
     }
   }
@@ -253,7 +253,7 @@ json State::get_display_sensors() {
 
       color_idx++;
     }
-    
+
   }
 
   return display_sensors;
@@ -277,8 +277,8 @@ json State::get_display_fans() {
       display_fans[e] = fans_by_id[e];
     }
   }
-		    
-  // hack to allow output_pin defined fans		    
+
+  // hack to allow output_pin defined fans
   auto output_pins = get_output_pins();
   for (auto &e : output_pins) {
     if (fans_by_id.contains(e)) {
@@ -323,7 +323,7 @@ json State::get_display_leds() {
       display_leds[e] = leds_by_id[e];
     }
   }
-		    
+
   // hack to allow output_pin defined leds
   auto output_pins = get_output_pins();
   for (auto &e : output_pins) {
@@ -344,7 +344,7 @@ json State::get_display_leds() {
 	};
       }
     }
-    
+
     for (auto &e: leds) {
       size_t pos = e.find_last_of(' ');
       std::string display_name = KUtils::to_title(pos != std::string::npos

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -63,7 +63,7 @@ json &State::get_data() {
   return data;
 }
 
-json &State::get_data(const json::json_pointer& ptr) {
+json &State::get_data(const json::json_pointer &ptr) {
   std::lock_guard<std::mutex> guard(lock);
   return data[ptr];
 }
@@ -82,8 +82,8 @@ std::vector<std::string> State::get_extruders() {
     for (auto &o : objects) {
       const std::string &obj_name = o.template get<std::string>();
       if (obj_name.rfind("extruder", 0) == 0
-	  && obj_name.rfind("extruder_stepper", 0) != 0) {
-	extruders.push_back(obj_name);
+        && obj_name.rfind("extruder_stepper", 0) != 0) {
+        extruders.push_back(obj_name);
       }
     }
   }
@@ -99,8 +99,8 @@ std::vector<std::string> State::get_heaters() {
     for (auto &o : objects) {
       const std::string &obj_name = o.template get<std::string>();
       if (obj_name == "heater_bed"
-	  || obj_name.rfind("heater_generic ", 0) == 0) {
-	heaters.push_back(obj_name);
+        || obj_name.rfind("heater_generic ", 0) == 0) {
+        heaters.push_back(obj_name);
       }
     }
   }
@@ -133,10 +133,10 @@ std::vector<std::string> State::get_fans() {
     for (auto &o : objects) {
       const std::string &obj_name = o.template get<std::string>();
       if (obj_name == "fan"
-	  || obj_name.rfind("heater_fan ", 0) == 0
-	  || obj_name.rfind("fan_generic ", 0) == 0
-	  || obj_name.rfind("controller_fan ", 0) == 0) {
-	fans.push_back(obj_name);
+        || obj_name.rfind("heater_fan ", 0) == 0
+        || obj_name.rfind("fan_generic ", 0) == 0
+        || obj_name.rfind("controller_fan ", 0) == 0) {
+        fans.push_back(obj_name);
       }
     }
   }
@@ -152,7 +152,7 @@ std::vector<std::string> State::get_leds() {
     for (auto &o : objects) {
       const std::string &obj_name = o.template get<std::string>();
       if (obj_name.rfind("led ", 0) == 0) {
-	leds.push_back(obj_name);
+        leds.push_back(obj_name);
       }
     }
   }
@@ -168,7 +168,7 @@ std::vector<std::string> State::get_output_pins() {
     for (auto &o : objects) {
       const std::string &obj_name = o.template get<std::string>();
       if (obj_name.rfind("output_pin ", 0) == 0) {
-	output_pins.push_back(obj_name);
+        output_pins.push_back(obj_name);
       }
     }
   }
@@ -215,40 +215,40 @@ json State::get_display_sensors() {
     // default to first extruders/heaters from printer objects
     uint32_t color_idx = 0;
     lv_palette_t color = GUPPY_COLORS[color_idx];
-    for (auto &e: extruders) {
+    for (auto &e : extruders) {
       spdlog::debug("default extruder {}", e);
       color = GUPPY_COLORS[color_idx % GUPPY_COLOR_SIZE];
       display_sensors[e] = {
-	{ "id", e },
-	{ "display_name", KUtils::to_title(e) },
-	{ "controllable", true },
-	{ "color", color }
+  { "id", e },
+  { "display_name", KUtils::to_title(e) },
+  { "controllable", true },
+  { "color", color }
       };
 
       color_idx++;
     }
 
-    for (auto &e: heaters) {
+    for (auto &e : heaters) {
       spdlog::debug("default heaters {}", e);
       color = GUPPY_COLORS[color_idx % GUPPY_COLOR_SIZE];
       display_sensors[e] = {
-	{ "id", e },
-	{ "display_name", KUtils::to_title(e) },
-	{ "controllable", true },
-	{ "color", color }
+  { "id", e },
+  { "display_name", KUtils::to_title(e) },
+  { "controllable", true },
+  { "color", color }
       };
 
       color_idx++;
     }
 
-    for (auto &e: sensors) {
+    for (auto &e : sensors) {
       spdlog::debug("default sensors {}", e);
       color = GUPPY_COLORS[color_idx % GUPPY_COLOR_SIZE];
       display_sensors[e] = {
-	{ "id", e },
-	{ "display_name", KUtils::to_title(e) },
-	{ "controllable", false },
-	{ "color", color }
+  { "id", e },
+  { "display_name", KUtils::to_title(e) },
+  { "controllable", false },
+  { "color", color }
       };
 
       color_idx++;
@@ -289,14 +289,14 @@ json State::get_display_fans() {
 
   // default to top standard fans
   if (display_fans.empty()) {
-    for (auto &e: fans) {
+    for (auto &e : fans) {
       size_t pos = e.find_last_of(' ');
       std::string display_name = KUtils::to_title(pos != std::string::npos
-						  ? e.substr(pos + 1)
-						  : "Part Fan");
+        ? e.substr(pos + 1)
+        : "Part Fan");
       display_fans[e] = {
-	{"id", e},
-	{"display_name", display_name}
+  {"id", e},
+  {"display_name", display_name}
       };
     }
   }
@@ -338,21 +338,21 @@ json State::get_display_leds() {
     for (auto &e : output_pins) {
       // hack to support k1 defined output_pin led
       if (e == "output_pin LED") {
-	display_leds["output_pin LED"] = {
-	  {"id", "output_pin LED"},
-	  {"display_name", "LED"}
-	};
+        display_leds["output_pin LED"] = {
+          {"id", "output_pin LED"},
+          {"display_name", "LED"}
+        };
       }
     }
 
-    for (auto &e: leds) {
+    for (auto &e : leds) {
       size_t pos = e.find_last_of(' ');
       std::string display_name = KUtils::to_title(pos != std::string::npos
-						  ? e.substr(pos + 1)
-						  : "LED");
+        ? e.substr(pos + 1)
+        : "LED");
       display_leds[e] = {
-	{"id", e},
-	{"display_name", display_name}
+  {"id", e},
+  {"display_name", display_name}
       };
     }
   }

--- a/src/sysinfo_panel.cpp
+++ b/src/sysinfo_panel.cpp
@@ -38,20 +38,22 @@ std::vector<std::string> SysInfoPanel::themes = {
 
 static std::map<int32_t, uint32_t> sleepsec_to_dd_idx = {
   {-1, 0}, // never
-  {300, 1}, // 5 min
-  {600, 2}, // 10 min
-  {1800, 3}, // 30 min
-  {3600, 4}, // 1 hour
-  {18000, 5} // 5 hour
+  {30, 1}, // 30 sec
+  {60, 2}, // 1 min
+  {300, 3}, // 5 min
+  {600, 4}, // 10 min
+  {1800, 5}, // 30 min
+  {3600, 6}, // 1 hour
 };
 
 static std::map<std::string, uint32_t> sleep_label_to_sec = {
   {"Never", -1}, // never
+  {"30 Seconds", 30}, // 30 sec
+  {"1 Minute", 60}, // 1 min
   {"5 Minutes", 300}, // 5 min
   {"10 Minutes", 600}, // 10 min
   {"30 Minutes", 1800}, // 30 min
   {"1 Hour", 3600}, // 1 hour
-  {"5 Hours", 18000} // 5 hour
 };
 
 SysInfoPanel::SysInfoPanel()
@@ -95,7 +97,7 @@ SysInfoPanel::SysInfoPanel()
   lv_obj_set_flex_align(left_cont, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
 
   lv_obj_clear_flag(right_cont, LV_OBJ_FLAG_SCROLLABLE);
-  lv_obj_set_size(right_cont, LV_PCT(50), LV_PCT(100));  
+  lv_obj_set_size(right_cont, LV_PCT(50), LV_PCT(100));
   lv_obj_set_flex_flow(right_cont, LV_FLEX_FLOW_COLUMN);
   lv_obj_set_flex_align(right_cont, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
 
@@ -107,12 +109,13 @@ SysInfoPanel::SysInfoPanel()
   lv_obj_align(l, LV_ALIGN_LEFT_MID, 0, 0);
   lv_obj_align(display_sleep_dd, LV_ALIGN_RIGHT_MID, 0, 0);
   lv_dropdown_set_options(display_sleep_dd,
-			  "Never\n"
-			  "5 Minutes\n"
+        "Never\n"
+        "30 Seconds\n"
+        "1 Minute\n"
+        "5 Minutes\n"
 			  "10 Minutes\n"
 			  "30 Minutes\n"
-			  "1 Hour\n"
-			  "5 Hours");
+			  "1 Hour");
 
   auto v = conf->get_json("/display_sleep_sec");
   if (!v.is_null()) {
@@ -124,7 +127,7 @@ SysInfoPanel::SysInfoPanel()
   }
   lv_obj_add_event_cb(display_sleep_dd, &SysInfoPanel::_handle_callback,
 		      LV_EVENT_VALUE_CHANGED, this);
-  
+
   lv_obj_set_size(ll_cont, LV_PCT(100), LV_SIZE_CONTENT);
   lv_obj_set_style_pad_all(ll_cont, 0, 0);
   l = lv_label_create(ll_cont);
@@ -220,7 +223,7 @@ SysInfoPanel::SysInfoPanel()
                       LV_EVENT_VALUE_CHANGED, this);
 
 
-  lv_obj_add_flag(back_btn.get_container(), LV_OBJ_FLAG_FLOATING);	
+  lv_obj_add_flag(back_btn.get_container(), LV_OBJ_FLAG_FLOATING);
   lv_obj_align(back_btn.get_container(), LV_ALIGN_BOTTOM_RIGHT, 0, 0);
 }
 

--- a/src/sysinfo_panel.cpp
+++ b/src/sysinfo_panel.cpp
@@ -62,20 +62,20 @@ SysInfoPanel::SysInfoPanel()
   , right_cont(lv_obj_create(cont))
   , network_label(lv_label_create(right_cont))
 
-    // display sleep
+  // display sleep
   , disp_sleep_cont(lv_obj_create(left_cont))
   , display_sleep_dd(lv_dropdown_create(disp_sleep_cont))
 
-    // log level
+  // log level
   , ll_cont(lv_obj_create(left_cont))
   , loglevel_dd(lv_dropdown_create(ll_cont))
   , loglevel(1)
 
-    // estop prompt
+  // estop prompt
   , estop_toggle_cont(lv_obj_create(left_cont))
   , prompt_estop_toggle(lv_switch_create(estop_toggle_cont))
 
-    // Z axis icons
+  // Z axis icons
   , z_icon_toggle_cont(lv_obj_create(left_cont))
   , z_icon_toggle(lv_switch_create(z_icon_toggle_cont))
 
@@ -109,13 +109,13 @@ SysInfoPanel::SysInfoPanel()
   lv_obj_align(l, LV_ALIGN_LEFT_MID, 0, 0);
   lv_obj_align(display_sleep_dd, LV_ALIGN_RIGHT_MID, 0, 0);
   lv_dropdown_set_options(display_sleep_dd,
-        "Never\n"
-        "30 Seconds\n"
-        "1 Minute\n"
-        "5 Minutes\n"
-			  "10 Minutes\n"
-			  "30 Minutes\n"
-			  "1 Hour");
+    "Never\n"
+    "30 Seconds\n"
+    "1 Minute\n"
+    "5 Minutes\n"
+    "10 Minutes\n"
+    "30 Minutes\n"
+    "1 Hour");
 
   auto v = conf->get_json("/display_sleep_sec");
   if (!v.is_null()) {
@@ -126,7 +126,7 @@ SysInfoPanel::SysInfoPanel()
     }
   }
   lv_obj_add_event_cb(display_sleep_dd, &SysInfoPanel::_handle_callback,
-		      LV_EVENT_VALUE_CHANGED, this);
+    LV_EVENT_VALUE_CHANGED, this);
 
   lv_obj_set_size(ll_cont, LV_PCT(100), LV_SIZE_CONTENT);
   lv_obj_set_style_pad_all(ll_cont, 0, 0);
@@ -151,7 +151,7 @@ SysInfoPanel::SysInfoPanel()
   }
 
   lv_obj_add_event_cb(loglevel_dd, &SysInfoPanel::_handle_callback,
-		      LV_EVENT_VALUE_CHANGED, this);
+    LV_EVENT_VALUE_CHANGED, this);
 
   lv_obj_set_size(estop_toggle_cont, LV_PCT(100), LV_SIZE_CONTENT);
   lv_obj_set_style_pad_all(estop_toggle_cont, 0, 0);
@@ -173,9 +173,9 @@ SysInfoPanel::SysInfoPanel()
   }
 
   lv_obj_add_event_cb(prompt_estop_toggle, &SysInfoPanel::_handle_callback,
-		      LV_EVENT_VALUE_CHANGED, this);
+    LV_EVENT_VALUE_CHANGED, this);
 
-    /* Z icon selection */
+  /* Z icon selection */
   lv_obj_set_size(z_icon_toggle_cont, LV_PCT(100), LV_SIZE_CONTENT);
   lv_obj_set_style_pad_all(z_icon_toggle_cont, 0, 0);
 
@@ -197,7 +197,7 @@ SysInfoPanel::SysInfoPanel()
   }
 
   lv_obj_add_event_cb(z_icon_toggle, &SysInfoPanel::_handle_callback,
-		      LV_EVENT_VALUE_CHANGED, this);
+    LV_EVENT_VALUE_CHANGED, this);
 
   // theme dropdown
   lv_obj_set_size(theme_cont, LV_PCT(100), LV_SIZE_CONTENT);
@@ -211,16 +211,16 @@ SysInfoPanel::SysInfoPanel()
 
   v = conf->get_json("/theme");
   if (!v.is_null()) {
-      auto it = std::find(themes.begin(), themes.end(), v.template get<std::string>());
-      if (it != std::end(themes)) {
-          theme = std::distance(themes.begin(), it);
-          lv_dropdown_set_selected(theme_dd, theme);
-      }
-  } else {
+    auto it = std::find(themes.begin(), themes.end(), v.template get<std::string>());
+    if (it != std::end(themes)) {
+      theme = std::distance(themes.begin(), it);
       lv_dropdown_set_selected(theme_dd, theme);
+    }
+  } else {
+    lv_dropdown_set_selected(theme_dd, theme);
   }
   lv_obj_add_event_cb(theme_dd, &SysInfoPanel::_handle_callback,
-                      LV_EVENT_VALUE_CHANGED, this);
+    LV_EVENT_VALUE_CHANGED, this);
 
 
   lv_obj_add_flag(back_btn.get_container(), LV_OBJ_FLAG_FLOATING);
@@ -245,7 +245,7 @@ void SysInfoPanel::foreground() {
     network_detail.push_back(fmt::format("\t{}: {}", iface, ip));
   }
   lv_label_set_text(network_label, fmt::format("{}\n\nGuppyScreen\n\tVersion: " GS_VERSION,
-					       fmt::join(network_detail, "\n")).c_str());
+    fmt::join(network_detail, "\n")).c_str());
 }
 
 void SysInfoPanel::handle_callback(lv_event_t *e)
@@ -257,8 +257,7 @@ void SysInfoPanel::handle_callback(lv_event_t *e)
     {
       lv_obj_move_background(cont);
     }
-  }
-  else if (lv_event_get_code(e) == LV_EVENT_VALUE_CHANGED) {
+  } else if (lv_event_get_code(e) == LV_EVENT_VALUE_CHANGED) {
     lv_obj_t *obj = lv_event_get_target(e);
     Config *conf = Config::get_instance();
     if (obj == loglevel_dd) {
@@ -275,13 +274,11 @@ void SysInfoPanel::handle_callback(lv_event_t *e)
           conf->save();
         }
       }
-    }
-    else if (obj == prompt_estop_toggle) {
+    } else if (obj == prompt_estop_toggle) {
       bool should_prompt = lv_obj_has_state(prompt_estop_toggle, LV_STATE_CHECKED);
       conf->set<bool>("/prompt_emergency_stop", should_prompt);
       conf->save();
-    }
-    else if (obj == display_sleep_dd) {
+    } else if (obj == display_sleep_dd) {
       char buf[64];
       lv_dropdown_get_selected_str(display_sleep_dd, buf, sizeof(buf));
       std::string sleep_label = std::string(buf);
@@ -291,8 +288,7 @@ void SysInfoPanel::handle_callback(lv_event_t *e)
         conf->set<int32_t>("/display_sleep_sec", el->second);
         conf->save();
       }
-    }
-    else if (obj == z_icon_toggle) {
+    } else if (obj == z_icon_toggle) {
       bool inverted = lv_obj_has_state(z_icon_toggle, LV_STATE_CHECKED);
       conf->set<bool>("/invert_z_icon", inverted);
       conf->save();

--- a/src/utils.h
+++ b/src/utils.h
@@ -16,7 +16,7 @@ namespace KUtils {
   std::string get_root_path(const std::string root_name);
 
   // path, width
-  std::pair<std::string, size_t> get_thumbnail(const std::string &gcode_file, json &j, double scale);
+  std::pair<std::string, std::pair<size_t, size_t>> get_thumbnail(const std::string &gcode_file, json &j, double scale);
 
   std::string download_file(const std::string &root,
 			    const std::string &fname,

--- a/src/utils.h
+++ b/src/utils.h
@@ -19,8 +19,8 @@ namespace KUtils {
   std::pair<std::string, std::pair<size_t, size_t>> get_thumbnail(const std::string &gcode_file, json &j, double scale);
 
   std::string download_file(const std::string &root,
-			    const std::string &fname,
-			    const std::string &dest);
+    const std::string &fname,
+    const std::string &dest);
 
   std::vector<std::string> get_interfaces();
   std::string interface_ip(const std::string &interface);
@@ -37,8 +37,8 @@ namespace KUtils {
   size_t bytes_to_mb(size_t s);
 
   template<typename T, typename U> void sort_map_values(std::map<T, U> v,
-							std::vector<U> &out_vect,
-							std::function<bool(U&, U&)> sorter) {
+    std::vector<U> &out_vect,
+    std::function<bool(U &, U &)> sorter) {
     for (auto &el : v) {
       out_vect.push_back(el.second);
     }

--- a/src/websocket_client.cpp
+++ b/src/websocket_client.cpp
@@ -61,7 +61,7 @@ int KWebSocketClient::connect(const char* url,
 
     if (j.contains("method")) {
       std::string method = j["method"].template get<std::string>();
-      if ("notify_status_update" == method) {
+      if ("notify_status_update" == method || "notify_filelist_changed" == method) {
         for (const auto &entry : notify_consumers) {
           entry->consume(j);
         }

--- a/src/wifi_panel.h
+++ b/src/wifi_panel.h
@@ -11,9 +11,9 @@
 #include <string>
 
 class WifiPanel {
- public:
+public:
   WifiPanel(std::mutex &l);
-  
+
   ~WifiPanel();
 
   void foreground();
@@ -25,21 +25,21 @@ class WifiPanel {
   bool find_current_network();
 
   static void _handle_back_btn(lv_event_t *event) {
-    WifiPanel *panel = (WifiPanel*)event->user_data;
+    WifiPanel *panel = (WifiPanel *)event->user_data;
     panel->handle_back_btn(event);
   };
-  
+
   static void _handle_callback(lv_event_t *event) {
-    WifiPanel *panel = (WifiPanel*)event->user_data;
+    WifiPanel *panel = (WifiPanel *)event->user_data;
     panel->handle_callback(event);
   };
-  
+
   static void _handle_kb_input(lv_event_t *e) {
-    WifiPanel *panel = (WifiPanel*)e->user_data;
+    WifiPanel *panel = (WifiPanel *)e->user_data;
     panel->handle_kb_input(e);
   };
 
- private:
+private:
   std::mutex &lv_lock;
   WpaEvent wpa_event;
   lv_obj_t *cont;
@@ -56,7 +56,7 @@ class WifiPanel {
   std::string cur_network;
   std::map<std::string, std::string> list_networks;
   std::map<std::string, int> wifi_name_db;
-  
+
 };
 
 #endif // __WIFI_PANEL_H__


### PR DESCRIPTION
**Note:** All these changes will now be hosted on [my version of GuppyScreen](https://github.com/probielodan/guppyscreen). I intend to support it with bug fixes and feature requests where possible. All these changes will start with version 0.0.27-beta to continue where Ballaswag left off.

#### Major Changes:

- **Fixed custom tick bug** that caused a reset every 71.58 minutes due to `uint32_t` wraparound.
- **Added support for temperature-controlled fans.**
- **Improved movement logic**: ensures absolute mode is restored after relative moves to prevent inconsistent behavior and crashes.
- **Auto-refresh file list** when print panel is brought to foreground.
- **Added speed control** (in addition to distance) for the homing panel.
- **More logical screen timeout durations.**
#### UI/UX Improvements:
- Buttons now **fill their container space** more appropriately (grid/flex layouts).
- **Subtle border** added around all buttons for better visual distinction.
- **Button reordering** for improved flow and experience.
- **Icon scaling fixed** on both print selection and print status screens.
#### Code Cleanup:
- Replaced all **tabs with spaces** in modified files for consistency.
- General formatting and minor refactors throughout.
#### Screenshots:
<img width="800" height="480" alt="guppyscreen_0" src="https://github.com/user-attachments/assets/187016ec-4fd5-44cb-8149-f2ed5a12aa4c" />
<img width="800" height="480" alt="guppyscreen_1" src="https://github.com/user-attachments/assets/bc3d0170-1999-43e0-89f6-fa87eed117d7" />
<img width="800" height="480" alt="guppyscreen_2" src="https://github.com/user-attachments/assets/f392ad0e-e628-4651-9132-c5752ec6c6e6" />
<img width="800" height="480" alt="guppyscreen_3" src="https://github.com/user-attachments/assets/382bf86d-0307-4a57-be66-0f00c820abf3" />
<img width="800" height="480" alt="guppyscreen_4" src="https://github.com/user-attachments/assets/65668b88-e793-4104-82e8-1f18bddf5e7c" />
<img width="800" height="480" alt="guppyscreen_6" src="https://github.com/user-attachments/assets/10db45e2-6c59-4be9-8b9d-ce0d500059aa" />
<img width="800" height="480" alt="guppyscreen_7" src="https://github.com/user-attachments/assets/12c839d3-3d0b-4d6f-b0ec-61e960018acd" />
<img width="800" height="480" alt="guppyscreen_8" src="https://github.com/user-attachments/assets/36f3621a-c73b-4a00-a918-7e11f0ce7f2e" />
<img width="800" height="480" alt="guppyscreen_9" src="https://github.com/user-attachments/assets/8e49fb74-c9fd-4451-b06e-16e9f965493f" />
<img width="800" height="480" alt="guppyscreen_10" src="https://github.com/user-attachments/assets/7f772349-cdb5-4522-bc32-06129ea4e49e" />
<img width="800" height="480" alt="guppyscreen_11" src="https://github.com/user-attachments/assets/642cc172-92e0-44c0-96c4-6c5c1ade17a6" />
<img width="800" height="480" alt="guppyscreen_12" src="https://github.com/user-attachments/assets/c119e961-1d81-45a4-8a93-fa5f4750f265" />
<img width="800" height="480" alt="guppyscreen_13" src="https://github.com/user-attachments/assets/d953f0d3-e785-4710-85ab-2aff29e95305" />